### PR TITLE
Rework Donwload & Import Items to a full character importer

### DIFF
--- a/WPFSKillTree/Computation/ViewModels/CalculationNodeViewModel.cs
+++ b/WPFSKillTree/Computation/ViewModels/CalculationNodeViewModel.cs
@@ -74,7 +74,7 @@ namespace PoESkillTree.Computation.ViewModels
             if (Value is null)
                 return L10n.Message("None");
             if (DataType.IsEnum)
-                return EnumValues.GetValue((int) Value.Single())!.ToString()!;
+                return EnumsNET.Enums.AsString(DataType, (uint) Value.Single());
             return Value.Select(d => Math.Round(d, 2, MidpointRounding.AwayFromZero))
                 .ToString()!.Replace(" to ", " \nto ");
         }

--- a/WPFSKillTree/Controls/Dialogs/BaseDialog.cs
+++ b/WPFSKillTree/Controls/Dialogs/BaseDialog.cs
@@ -16,6 +16,15 @@ namespace PoESkillTree.Controls.Dialogs
     /// </summary>
     public class BaseDialog : BaseMetroDialog
     {
+        public static readonly DependencyProperty MinContentWidthProperty = DependencyProperty.Register(
+            "MinContentWidth", typeof(double), typeof(BaseDialog), new PropertyMetadata(0D));
+
+        public double MinContentWidth
+        {
+            get => (double) GetValue(MinContentWidthProperty);
+            set => SetValue(MinContentWidthProperty, value);
+        }
+
         public static readonly DependencyProperty MaxContentWidthProperty =
             DependencyProperty.Register("MaxContentWidth", typeof(double), typeof(BaseDialog), new PropertyMetadata(double.PositiveInfinity));
 
@@ -27,8 +36,8 @@ namespace PoESkillTree.Controls.Dialogs
         /// </summary>
         public double MaxContentWidth
         {
-            get { return (double) GetValue(MaxContentWidthProperty); }
-            set { SetValue(MaxContentWidthProperty, value); }
+            get => (double) GetValue(MaxContentWidthProperty);
+            set => SetValue(MaxContentWidthProperty, value);
         }
 
         public static readonly DependencyProperty CloseButtonVisibilityProperty =
@@ -41,8 +50,8 @@ namespace PoESkillTree.Controls.Dialogs
         /// </summary>
         public Visibility CloseButtonVisibility
         {
-            get { return (Visibility) GetValue(CloseButtonVisibilityProperty); }
-            set { SetValue(CloseButtonVisibilityProperty, value); }
+            get => (Visibility) GetValue(CloseButtonVisibilityProperty);
+            set => SetValue(CloseButtonVisibilityProperty, value);
         }
 
         public static readonly DependencyProperty CloseCommandProperty =
@@ -53,8 +62,8 @@ namespace PoESkillTree.Controls.Dialogs
         /// </summary>
         public ICommand CloseCommand
         {
-            get { return (ICommand) GetValue(CloseCommandProperty); }
-            set { SetValue(CloseCommandProperty, value); }
+            get => (ICommand) GetValue(CloseCommandProperty);
+            set => SetValue(CloseCommandProperty, value);
         }
 
         public static readonly DependencyProperty CloseCommandParameterProperty = DependencyProperty.Register(
@@ -65,8 +74,8 @@ namespace PoESkillTree.Controls.Dialogs
         /// </summary>
         public object CloseCommandParameter
         {
-            get { return GetValue(CloseCommandParameterProperty); }
-            set { SetValue(CloseCommandParameterProperty, value); }
+            get => GetValue(CloseCommandParameterProperty);
+            set => SetValue(CloseCommandParameterProperty, value);
         }
 
         public static readonly DependencyProperty DialogLeftProperty =
@@ -77,8 +86,8 @@ namespace PoESkillTree.Controls.Dialogs
         /// </summary>
         public object DialogLeft
         {
-            get { return GetValue(DialogLeftProperty); }
-            set { SetValue(DialogLeftProperty, value); }
+            get => GetValue(DialogLeftProperty);
+            set => SetValue(DialogLeftProperty, value);
         }
 
         static BaseDialog()

--- a/WPFSKillTree/Controls/Dialogs/DialogCoordinator.cs
+++ b/WPFSKillTree/Controls/Dialogs/DialogCoordinator.cs
@@ -67,7 +67,7 @@ namespace PoESkillTree.Controls.Dialogs
             return metroWindow.Invoke(() => metroWindow.ShowInfoAsync(message, details, title));
         }
 
-        public Task<string> ShowInputAsync(object context, string title, string message, string defaultText = "")
+        public Task<string?> ShowInputAsync(object context, string title, string message, string defaultText = "")
         {
             var metroWindow = GetMetroWindow(context);
             return metroWindow.Invoke(() => metroWindow.ShowInputAsync(title, message, defaultText));

--- a/WPFSKillTree/Controls/Dialogs/DialogCoordinator.cs
+++ b/WPFSKillTree/Controls/Dialogs/DialogCoordinator.cs
@@ -91,9 +91,8 @@ namespace PoESkillTree.Controls.Dialogs
         public Task<string?> ShowValidatingInputDialogAsync(object context, string title, string message,
             string defaultText, Func<string, string?> inputValidationFunc)
         {
-            return ShowDialogAsync(context,
-                new ValidatingInputDialogViewModel(title, message, defaultText, inputValidationFunc),
-                new ValidatingInputDialogView());
+            var metroWindow = GetMetroWindow(context);
+            return metroWindow.Invoke(() => metroWindow.ShowValidatingInputDialogAsync(title, message, inputValidationFunc, defaultText));
         }
     }
 }

--- a/WPFSKillTree/Controls/Dialogs/ExtendedDialogManager.cs
+++ b/WPFSKillTree/Controls/Dialogs/ExtendedDialogManager.cs
@@ -74,13 +74,14 @@ namespace PoESkillTree.Controls.Dialogs
 
         public static Task<string?> ShowInputAsync(this MetroWindow window, string title, string message, string defaultText = "")
         {
-            var settings = new MetroDialogSettings
-            {
-                NegativeButtonText = L10n.Message("Cancel"),
-                AffirmativeButtonText = L10n.Message("OK"),
-                DefaultText = defaultText,
-            };
-            return window.ShowInputAsync(title, message, settings);
+            return window.ShowValidatingInputDialogAsync(title, message, _ => null, defaultText);
+        }
+
+        public static Task<string?> ShowValidatingInputDialogAsync(this MetroWindow window,
+            string title, string message, Func<string, string?> inputValidationFunc, string defaultText = "")
+        {
+            return window.ShowDialogAsync(new ValidatingInputDialogViewModel(title, message, defaultText, inputValidationFunc),
+                new ValidatingInputDialogView());
         }
 
         public static async Task<ProgressDialogController> ShowProgressAsync(this MetroWindow window, string title,

--- a/WPFSKillTree/Controls/Dialogs/ExtendedDialogManager.cs
+++ b/WPFSKillTree/Controls/Dialogs/ExtendedDialogManager.cs
@@ -72,13 +72,13 @@ namespace PoESkillTree.Controls.Dialogs
             return ShowAsync(window, message, details, title ?? L10n.Message("Information"), MessageBoxButton.OK, MessageBoxImage.Information);
         }
 
-        public static Task<string> ShowInputAsync(this MetroWindow window, string title, string message, string defaultText = "")
+        public static Task<string?> ShowInputAsync(this MetroWindow window, string title, string message, string defaultText = "")
         {
             var settings = new MetroDialogSettings
             {
                 NegativeButtonText = L10n.Message("Cancel"),
                 AffirmativeButtonText = L10n.Message("OK"),
-                DefaultText = defaultText
+                DefaultText = defaultText,
             };
             return window.ShowInputAsync(title, message, settings);
         }

--- a/WPFSKillTree/Controls/Dialogs/IDialogCoordinator.cs
+++ b/WPFSKillTree/Controls/Dialogs/IDialogCoordinator.cs
@@ -24,7 +24,7 @@ namespace PoESkillTree.Controls.Dialogs
         /// <param name="message">A message shown in the dialog</param>
         /// <param name="defaultText">The text that the input box initially contains</param>
         /// <returns>The text entered by the user or null if the dialog was canceled</returns>
-        Task<string> ShowInputAsync(object context, string title, string message, string defaultText = "");
+        Task<string?> ShowInputAsync(object context, string title, string message, string defaultText = "");
 
         Task<ProgressDialogController> ShowProgressAsync(object context, string title, string message,
             bool isCancelable = false);

--- a/WPFSKillTree/Controls/Dialogs/ViewModels/ValidatingInputDialogViewModel.cs
+++ b/WPFSKillTree/Controls/Dialogs/ViewModels/ValidatingInputDialogViewModel.cs
@@ -17,8 +17,8 @@ namespace PoESkillTree.Controls.Dialogs.ViewModels
 
         public string Input
         {
-            get { return _input; }
-            set { SetProperty(ref _input, value); }
+            get => _input;
+            set => SetProperty(ref _input, value);
         }
 
 #pragma warning disable CS8618 // _input is set through Input

--- a/WPFSKillTree/Controls/Dialogs/Views/ValidatingInputDialogView.xaml
+++ b/WPFSKillTree/Controls/Dialogs/Views/ValidatingInputDialogView.xaml
@@ -28,7 +28,9 @@
                  controls:ControlsHelper.FocusBorderBrush="{DynamicResource MahApps.Brushes.Accent}"
                  controls:TextBoxHelper.SelectAllOnFocus="True"
                  Text="{Binding Input, UpdateSourceTrigger=PropertyChanged}"
-                 TextWrapping="Wrap" />
+                 TextWrapping="Wrap"
+                 MaxLines="10"
+                 VerticalScrollBarVisibility="Auto" />
 
         <StackPanel Grid.Row="2"
                     Style="{StaticResource DialogPanel}">

--- a/WPFSKillTree/Model/Builds/PoEBuild.cs
+++ b/WPFSKillTree/Model/Builds/PoEBuild.cs
@@ -21,6 +21,7 @@ namespace PoESkillTree.Model.Builds
         private string? _characterName;
         private string? _accountName;
         private string? _league;
+        private Realm _realm;
         private int _level = 1;
         private string _treeUrl = Constants.DefaultTree;
         private string? _itemData;
@@ -68,6 +69,12 @@ namespace PoESkillTree.Model.Builds
         {
             get => _league;
             set => SetProperty(ref _league, value);
+        }
+
+        public Realm Realm
+        {
+            get => _realm;
+            set => SetProperty(ref _realm, value);
         }
 
         /// <summary>
@@ -330,6 +337,7 @@ namespace PoESkillTree.Model.Builds
                 target.CharacterName = _build.CharacterName;
                 target.AccountName = _build.AccountName;
                 target.League = _build.League;
+                target.Realm = _build.Realm;
                 target.Level = _build.Level;
                 target.TreeUrl = _build.TreeUrl;
                 target.ItemData = _build.ItemData;

--- a/WPFSKillTree/Model/Builds/Realm.cs
+++ b/WPFSKillTree/Model/Builds/Realm.cs
@@ -1,0 +1,14 @@
+﻿namespace PoESkillTree.Model.Builds
+{
+    public enum Realm
+    {
+        PC,
+        XBox,
+        Sony
+    }
+
+    public static class RealmExtensions
+    {
+        public static string ToGGGIdentifier(this Realm @this) => @this.ToString().ToLowerInvariant();
+    }
+}

--- a/WPFSKillTree/Model/Items/ItemAttributes.cs
+++ b/WPFSKillTree/Model/Items/ItemAttributes.cs
@@ -225,6 +225,19 @@ namespace PoESkillTree.Model.Items
             }
         }
 
+        public void DeserializePassiveTreeJewels(JObject treeImportJson)
+        {
+            if (!treeImportJson.TryGetValue("items", out var itemsJson) || !treeImportJson.TryGetValue("jewel_slots", out var socketsJson))
+                return;
+            
+            var sockets = socketsJson.Values<ushort>().ToList();
+            foreach (var itemJson in itemsJson.Values<JObject>())
+            {
+                var item = new Item(_equipmentData, itemJson, ItemSlot.SkillTree);
+                SetItemInSlot(item, ItemSlot.SkillTree, sockets[item.X]);
+            }
+        }
+
         private void DeserializeSkills(JObject itemData)
         {
             if (!itemData.TryGetValue("skills", out var skillJson))

--- a/WPFSKillTree/Model/Serialization/AbstractPersistentDataDeserializer.cs
+++ b/WPFSKillTree/Model/Serialization/AbstractPersistentDataDeserializer.cs
@@ -161,6 +161,7 @@ namespace PoESkillTree.Model.Serialization
                 ItemData = build.ItemData,
                 LastUpdated = build.LastUpdated,
                 League = build.League,
+                Realm = build.Realm,
                 Level = build.Level,
                 Name = build.Name,
                 Note = build.Note,

--- a/WPFSKillTree/Model/Serialization/PersistentDataSerializer.cs
+++ b/WPFSKillTree/Model/Serialization/PersistentDataSerializer.cs
@@ -283,6 +283,7 @@ namespace PoESkillTree.Model.Serialization
                 ItemData = build.ItemData,
                 LastUpdated = build.LastUpdated,
                 League = build.League,
+                Realm = build.Realm,
                 Level = build.Level,
                 Name = build.Name,
                 Note = build.Note,

--- a/WPFSKillTree/Model/Serialization/XmlBuild.cs
+++ b/WPFSKillTree/Model/Serialization/XmlBuild.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;
+using PoESkillTree.Model.Builds;
 
 namespace PoESkillTree.Model.Serialization
 {
@@ -20,6 +21,8 @@ namespace PoESkillTree.Model.Serialization
         public string? AccountName { get; set; }
 
         public string? League { get; set; }
+
+        public Realm Realm { get; set; }
 
         public int Level { get; set; }
 

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -181,9 +181,6 @@ namespace PoESkillTree.SkillTreeFiles
 
         private CharacterClass _charClass;
         private int _asctype;
-        public static int UndefinedLevel => 0;
-        public static int MaximumLevel => 100;
-        private int _level = UndefinedLevel;
 
         public static PoESkillTree PoESkillTree { get; private set; }
         private static PoESkillTreeOptions PoESkillTreeOptions { get; set; }
@@ -429,12 +426,6 @@ namespace PoESkillTree.SkillTreeFiles
             _initialized = true;
         }
 
-        public int Level
-        {
-            get => _level;
-            set => SetProperty(ref _level, value);
-        }
-
         /// <summary>
         /// This will get all skill points related to the tree both Normal and Ascendancy
         /// </summary>
@@ -450,7 +441,7 @@ namespace PoESkillTree.SkillTreeFiles
             };
 
             var bandits = _persistentData.CurrentBuild.Bandits;
-            points["NormalTotal"] += Level - 1;
+            points["NormalTotal"] += _persistentData.CurrentBuild.Level - 1;
             if (bandits.Choice == Bandit.None)
                 points["NormalTotal"] += 2;
 
@@ -537,7 +528,7 @@ namespace PoESkillTree.SkillTreeFiles
         public Dictionary<string, List<float>>? HighlightedAttributes { get; set; }
 
         public Dictionary<string, List<float>> SelectedAttributes
-            => GetAttributes(SkilledNodes, CharClass, Level, _persistentData.CurrentBuild.Bandits);
+            => GetAttributes(SkilledNodes, CharClass, _persistentData.CurrentBuild.Level, _persistentData.CurrentBuild.Bandits);
 
         public static Dictionary<string, List<float>> GetAttributes(
             IEnumerable<SkillNode> skilledNodes, CharacterClass charClass, int level, BanditSettings banditSettings)

--- a/WPFSKillTree/Themes/BaseDialog.xaml
+++ b/WPFSKillTree/Themes/BaseDialog.xaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:l="clr-namespace:PoESkillTree.Localization.XAML"
-                    xmlns:dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs;assembly=MahApps.Metro"
                     xmlns:controls="clr-namespace:PoESkillTree.Controls.Dialogs"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -90,7 +89,7 @@
     </ControlTemplate>
 
     <Style TargetType="{x:Type controls:BaseDialog}"
-           BasedOn="{StaticResource {x:Type dialogs:BaseMetroDialog}}">
+           BasedOn="{StaticResource MahApps.Styles.BaseMetroDialog}">
         <d:Style.DataContext>
             <x:Type Type="viewModels:ViewModelBase" />
         </d:Style.DataContext>

--- a/WPFSKillTree/Themes/BaseDialog.xaml
+++ b/WPFSKillTree/Themes/BaseDialog.xaml
@@ -34,7 +34,9 @@
             <Grid Grid.Row="1">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="25*" />
-                    <ColumnDefinition Width="50*" MaxWidth="{TemplateBinding MaxContentWidth}" />
+                    <ColumnDefinition Width="50*"
+                                      MinWidth="{TemplateBinding MinContentWidth}"
+                                      MaxWidth="{TemplateBinding MaxContentWidth}" />
                     <ColumnDefinition Width="25*" />
                 </Grid.ColumnDefinitions>
                 <ContentPresenter Grid.Column="0" Content="{TemplateBinding DialogLeft}" />

--- a/WPFSKillTree/TreeGenerator/ViewModels/SettingsViewModel.cs
+++ b/WPFSKillTree/TreeGenerator/ViewModels/SettingsViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
+using PoESkillTree.Model;
 using PoESkillTree.Model.JsonSettings;
 using PoESkillTree.SkillTreeFiles;
 
@@ -44,7 +45,7 @@ namespace PoESkillTree.TreeGenerator.ViewModels
         /// <param name="tree">The skill tree to operate on. (not null)</param>
         /// <param name="dialogCoordinator"></param>
         /// <param name="dialogContext">The context used for <paramref name="dialogCoordinator"/>.</param>
-        public SettingsViewModel(SkillTree tree, ISettingsDialogCoordinator dialogCoordinator, object dialogContext)
+        public SettingsViewModel(SkillTree tree, IPersistentData persistentData, ISettingsDialogCoordinator dialogCoordinator, object dialogContext)
         {
             Tree = tree;
             _dialogCoordinator = dialogCoordinator;
@@ -56,7 +57,7 @@ namespace PoESkillTree.TreeGenerator.ViewModels
             Tabs = new ObservableCollection<GeneratorTabViewModel>
             {
                 new SteinerTabViewModel(Tree, _dialogCoordinator, _dialogContext, RunCallback),
-                new AdvancedTabViewModel(Tree, _dialogCoordinator, _dialogContext, RunCallback),
+                new AdvancedTabViewModel(Tree, persistentData, _dialogCoordinator, _dialogContext, RunCallback),
                 new AutomatedTabViewModel(Tree, _dialogCoordinator, _dialogContext, RunCallback)
             };
             SubSettings = new ISetting[] {SelectedTabIndex}.Union(Tabs).ToArray();

--- a/WPFSKillTree/TreeGenerator/ViewModels/SettingsViewModel.cs
+++ b/WPFSKillTree/TreeGenerator/ViewModels/SettingsViewModel.cs
@@ -43,6 +43,7 @@ namespace PoESkillTree.TreeGenerator.ViewModels
         /// Constructs a new SettingsViewModel that operates on the given skill tree.
         /// </summary>
         /// <param name="tree">The skill tree to operate on. (not null)</param>
+        /// <param name="persistentData"></param>
         /// <param name="dialogCoordinator"></param>
         /// <param name="dialogContext">The context used for <paramref name="dialogCoordinator"/>.</param>
         public SettingsViewModel(SkillTree tree, IPersistentData persistentData, ISettingsDialogCoordinator dialogCoordinator, object dialogContext)

--- a/WPFSKillTree/TreeGenerator/ViewModels/TreeGeneratorInteraction.cs
+++ b/WPFSKillTree/TreeGenerator/ViewModels/TreeGeneratorInteraction.cs
@@ -34,7 +34,7 @@ namespace PoESkillTree.TreeGenerator.ViewModels
                 {
                     if (_treeGeneratorViewModel != null)
                         _treeGeneratorViewModel.RunFinished -= ViewModelRunFinished;
-                    _treeGeneratorViewModel = new SettingsViewModel(SkillTree, SettingsDialogCoordinator.Instance, this);
+                    _treeGeneratorViewModel = new SettingsViewModel(SkillTree, _persistentData, SettingsDialogCoordinator.Instance, this);
                     _treeGeneratorViewModel.RunFinished += ViewModelRunFinished;
                     LoadSettings();
                 });

--- a/WPFSKillTree/TreeGenerator/Views/AdvancedGeneratorTab.xaml
+++ b/WPFSKillTree/TreeGenerator/Views/AdvancedGeneratorTab.xaml
@@ -100,9 +100,9 @@
         </Label>
         <metroControls:NumericUpDown Grid.Row="0" Grid.Column="1"
                                      Margin="0 5"
-                                     Minimum="{Binding Tree.UndefinedLevel}" Maximum="{Binding Tree.MaximumLevel}"
+                                     Minimum="0" Maximum="100"
                                      NumericInputMode="Numbers"
-                                     Value="{Binding Tree.Level}" />
+                                     Value="{Binding PersistentData.CurrentBuild.Level}" />
 
         <Label Grid.Row="1" Grid.Column="0"
                Margin="5">
@@ -119,6 +119,7 @@
         </Label>
         <TextBox Grid.Row="2" Grid.Column="1"
                  Margin="0 5" Padding="0 0 45 0"
+                 VerticalContentAlignment="Center"
                  HorizontalContentAlignment="Right"
                  Text="{Binding TotalPoints, Mode=OneWay}" IsReadOnly="True" />
 

--- a/WPFSKillTree/Utils/NotifyingTask.cs
+++ b/WPFSKillTree/Utils/NotifyingTask.cs
@@ -45,6 +45,9 @@ namespace PoESkillTree.Utils
             TaskCompletion = task.IsCompleted ? System.Threading.Tasks.Task.CompletedTask : WatchTaskAsync();
         }
 
+        public static NotifyingTask<TResult> FromResult(TResult result) =>
+            new NotifyingTask<TResult>(System.Threading.Tasks.Task.FromResult(result), _ => { });
+
         private async Task WatchTaskAsync()
         {
             try

--- a/WPFSKillTree/Utils/Util.cs
+++ b/WPFSKillTree/Utils/Util.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using MoreLinq;
 
 namespace PoESkillTree.Utils
@@ -20,6 +21,11 @@ namespace PoESkillTree.Utils
                 i++;
             }
             return name + $" ({i})";
+        }
+
+        public static void OpenInBrowser(string url)
+        {
+            Process.Start(new ProcessStartInfo(url) {UseShellExecute = true});
         }
     }
 }

--- a/WPFSKillTree/Utils/Wpf/EnumMarkupExtension.cs
+++ b/WPFSKillTree/Utils/Wpf/EnumMarkupExtension.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Windows.Markup;
+using EnumsNET;
+
+namespace PoESkillTree.Utils.Wpf
+{
+    public class EnumMarkupExtension : MarkupExtension
+    {
+        private readonly Type _enumType;
+
+        public EnumMarkupExtension(Type enumType)
+        {
+            _enumType = enumType;
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider) =>
+            Enums.GetValues(_enumType);
+    }
+}

--- a/WPFSKillTree/Utils/Wpf/Helper.cs
+++ b/WPFSKillTree/Utils/Wpf/Helper.cs
@@ -47,7 +47,7 @@ namespace PoESkillTree.Utils.Wpf
             if (hyperlink == null)
                 return;
 
-            hyperlink.RequestNavigate += (sender, args) => Process.Start(args.Uri.ToString());
+            hyperlink.RequestNavigate += (sender, args) => Util.OpenInBrowser(args.Uri.ToString());
         }
 
         /// <summary>

--- a/WPFSKillTree/ViewModels/Equipment/ImportCharacterViewModel.cs
+++ b/WPFSKillTree/ViewModels/Equipment/ImportCharacterViewModel.cs
@@ -7,7 +7,7 @@ using PoESkillTree.Model.Builds;
 
 namespace PoESkillTree.ViewModels.Equipment
 {
-    public class DownloadItemsViewModel : CloseableViewModel
+    public class ImportCharacterViewModel : CloseableViewModel
     {
         public PoEBuild Build { get; }
 
@@ -21,9 +21,9 @@ namespace PoESkillTree.ViewModels.Equipment
         private RelayCommand? _openInBrowserCommand;
         public ICommand OpenInBrowserCommand => _openInBrowserCommand ??= new RelayCommand(() => Process.Start(ItemsLink));
 
-        public DownloadItemsViewModel(PoEBuild build)
+        public ImportCharacterViewModel(PoEBuild build)
         {
-            DisplayName = L10n.Message("Download & Import Items");
+            DisplayName = L10n.Message("Import Character");
             Build = build;
             Build.PropertyChanged += BuildOnPropertyChanged;
             _itemsLink = CreateItemsLink();

--- a/WPFSKillTree/ViewModels/Equipment/ImportStashViewModel.cs
+++ b/WPFSKillTree/ViewModels/Equipment/ImportStashViewModel.cs
@@ -21,7 +21,7 @@ using PoESkillTree.Model.Items;
 
 namespace PoESkillTree.ViewModels.Equipment
 {
-    public class DownloadStashViewModel : CloseableViewModel
+    public class ImportStashViewModel : CloseableViewModel
     {
         private readonly StashViewModel _stash;
         private readonly IPersistentData _persistentData;
@@ -62,7 +62,7 @@ namespace PoESkillTree.ViewModels.Equipment
         private ICommand? _loadTabContentsCommand;
         public ICommand LoadTabContentsCommand => _loadTabContentsCommand ??= new AsyncRelayCommand(LoadTabContents);
 
-        public DownloadStashViewModel(
+        public ImportStashViewModel(
             IDialogCoordinator dialogCoordinator, IPersistentData persistentData, StashViewModel stash)
         {
             _stash = stash;

--- a/WPFSKillTree/ViewModels/Import/AccountCharacterViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/AccountCharacterViewModel.cs
@@ -2,17 +2,21 @@
 {
     public class AccountCharacterViewModel
     {
-        public AccountCharacterViewModel(string name, string league, string @class, int level)
+        public AccountCharacterViewModel(string name, string league, string @class, int classId, int ascendancyClass, int level)
         {
             Name = name;
             League = league;
             Class = @class;
+            ClassId = classId;
+            AscendancyClass = ascendancyClass;
             Level = level;
         }
 
         public string Name { get; }
         public string League { get; }
         public string Class { get; }
+        public int ClassId { get; }
+        public int AscendancyClass { get; }
         public int Level { get; }
     }
 }

--- a/WPFSKillTree/ViewModels/Import/AccountCharacterViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/AccountCharacterViewModel.cs
@@ -1,0 +1,18 @@
+﻿namespace PoESkillTree.ViewModels.Import
+{
+    public class AccountCharacterViewModel
+    {
+        public AccountCharacterViewModel(string name, string league, string @class, int level)
+        {
+            Name = name;
+            League = league;
+            Class = @class;
+            Level = level;
+        }
+
+        public string Name { get; }
+        public string League { get; }
+        public string Class { get; }
+        public int Level { get; }
+    }
+}

--- a/WPFSKillTree/ViewModels/Import/AccountCharactersViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/AccountCharactersViewModel.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NLog;
+using PoESkillTree.Engine.Utils.Extensions;
+using PoESkillTree.Model.Builds;
+using PoESkillTree.Utils;
+
+namespace PoESkillTree.ViewModels.Import
+{
+    public class AccountCharactersViewModel
+    {
+        private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+        private const string CharactersEndpoint = "https://www.pathofexile.com/character-window/get-characters?";
+
+        private readonly HttpClient _httpClient;
+        private readonly Dictionary<(Realm, string?), NotifyingTask<IReadOnlyList<AccountCharacterViewModel>>> _tasks =
+            new Dictionary<(Realm, string?), NotifyingTask<IReadOnlyList<AccountCharacterViewModel>>>();
+
+        public AccountCharactersViewModel(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public NotifyingTask<IReadOnlyList<AccountCharacterViewModel>> Get(Realm realm, string? accountName) =>
+            _tasks.GetOrAdd((realm, accountName), CreateTask);
+
+        private NotifyingTask<IReadOnlyList<AccountCharacterViewModel>> CreateTask((Realm realm, string? accountName) tuple) =>
+            new NotifyingTask<IReadOnlyList<AccountCharacterViewModel>>(LoadAsync(tuple.realm, tuple.accountName),
+                e => Log.Error(e, $"Could not retrieve the characters of {tuple.accountName} on {tuple.realm}"));
+
+        private async Task<IReadOnlyList<AccountCharacterViewModel>> LoadAsync(Realm realm, string? accountName)
+        {
+            if (string.IsNullOrEmpty(accountName))
+                return Array.Empty<AccountCharacterViewModel>();
+
+            var requestUrl = $"{CharactersEndpoint}realm={realm.ToGGGIdentifier()}&accountName={accountName}";
+            var result = await _httpClient.GetAsync(requestUrl);
+            result.EnsureSuccessStatusCode();
+            var contents = await result.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<IReadOnlyList<AccountCharacterViewModel>>(contents);
+        }
+    }
+}

--- a/WPFSKillTree/ViewModels/Import/CurrentLeaguesViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/CurrentLeaguesViewModel.cs
@@ -4,9 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NLog;
-using PoESkillTree.Controls.Dialogs;
 using PoESkillTree.Engine.Utils.Extensions;
-using PoESkillTree.Localization;
 using PoESkillTree.Model.Builds;
 using PoESkillTree.Utils;
 
@@ -18,14 +16,12 @@ namespace PoESkillTree.ViewModels.Import
 
         private const string LeaguesEndpoint = "https://www.pathofexile.com/api/leagues?type=main&compat=1&";
 
-        private readonly IDialogCoordinator _dialogCoordinator;
         private readonly HttpClient _httpClient;
         private readonly Dictionary<Realm, NotifyingTask<IReadOnlyList<string>>> _leagueTasks =
             new Dictionary<Realm, NotifyingTask<IReadOnlyList<string>>>();
 
-        public CurrentLeaguesViewModel(IDialogCoordinator dialogCoordinator, HttpClient httpClient)
+        public CurrentLeaguesViewModel(HttpClient httpClient)
         {
-            _dialogCoordinator = dialogCoordinator;
             _httpClient = httpClient;
         }
 
@@ -34,18 +30,14 @@ namespace PoESkillTree.ViewModels.Import
 
         private NotifyingTask<IReadOnlyList<string>> CreateTask(Realm realm) =>
             new NotifyingTask<IReadOnlyList<string>>(LoadAsync(realm),
-                async e =>
-                {
-                    Log.Error(e, "Could not load the currently running leagues for realm " + realm);
-                    await _dialogCoordinator.ShowWarningAsync(this,
-                        L10n.Message("Could not load the currently running leagues."), e.Message);
-                });
+                e => Log.Error(e, "Could not retrieve the currently running leagues for realm " + realm));
 
         private async Task<IReadOnlyList<string>> LoadAsync(Realm realm)
         {
-            var file = await _httpClient.GetStringAsync($"{LeaguesEndpoint}realm={realm.ToGGGIdentifier()}")
-                .ConfigureAwait(false);
-            return JArray.Parse(file).Select(t => t["id"]!.Value<string>()).ToList();
+            var result = await _httpClient.GetAsync($"{LeaguesEndpoint}realm={realm.ToGGGIdentifier()}");
+            result.EnsureSuccessStatusCode();
+            var contents = await result.Content.ReadAsStringAsync();
+            return JArray.Parse(contents).Select(t => t["id"]!.Value<string>()).ToList();
         }
     }
 }

--- a/WPFSKillTree/ViewModels/Import/CurrentLeaguesViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/CurrentLeaguesViewModel.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NLog;
+using PoESkillTree.Controls.Dialogs;
+using PoESkillTree.Engine.Utils.Extensions;
+using PoESkillTree.Localization;
+using PoESkillTree.Model.Builds;
+using PoESkillTree.Utils;
+
+namespace PoESkillTree.ViewModels.Import
+{
+    public class CurrentLeaguesViewModel
+    {
+        private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+        private const string LeaguesEndpoint = "https://www.pathofexile.com/api/leagues?type=main&compat=1&";
+
+        private readonly IDialogCoordinator _dialogCoordinator;
+        private readonly HttpClient _httpClient;
+        private readonly Dictionary<Realm, NotifyingTask<IReadOnlyList<string>>> _leagueTasks =
+            new Dictionary<Realm, NotifyingTask<IReadOnlyList<string>>>();
+
+        public CurrentLeaguesViewModel(IDialogCoordinator dialogCoordinator, HttpClient httpClient)
+        {
+            _dialogCoordinator = dialogCoordinator;
+            _httpClient = httpClient;
+        }
+
+        public NotifyingTask<IReadOnlyList<string>> this[Realm realm] =>
+            _leagueTasks.GetOrAdd(realm, CreateTask);
+
+        private NotifyingTask<IReadOnlyList<string>> CreateTask(Realm realm) =>
+            new NotifyingTask<IReadOnlyList<string>>(LoadAsync(realm),
+                async e =>
+                {
+                    Log.Error(e, "Could not load the currently running leagues for realm " + realm);
+                    await _dialogCoordinator.ShowWarningAsync(this,
+                        L10n.Message("Could not load the currently running leagues."), e.Message);
+                });
+
+        private async Task<IReadOnlyList<string>> LoadAsync(Realm realm)
+        {
+            var file = await _httpClient.GetStringAsync($"{LeaguesEndpoint}realm={realm.ToGGGIdentifier()}")
+                .ConfigureAwait(false);
+            return JArray.Parse(file).Select(t => t["id"]!.Value<string>()).ToList();
+        }
+    }
+}

--- a/WPFSKillTree/ViewModels/Import/ImportCharacterViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/ImportCharacterViewModel.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json.Linq;
 using NLog;
 using PoESkillTree.Common.ViewModels;
 using PoESkillTree.Controls.Dialogs;
+using PoESkillTree.Engine.GameModel.Items;
 using PoESkillTree.Localization;
 using PoESkillTree.Model.Builds;
 using PoESkillTree.Model.Items;
@@ -186,13 +187,28 @@ namespace PoESkillTree.ViewModels.Import
             if (string.IsNullOrEmpty(importJson))
                 return Unit.Default;
 
-            var import = JObject.Parse(importJson);
+            if (importItems)
+            {
+                var toRemove = _itemAttributes.Equip.Where(i => i.Slot != ItemSlot.SkillTree).ToList();
+                foreach (var item in toRemove)
+                {
+                    _itemAttributes.RemoveItem(item);
+                }
+            }
+            if (importSkills)
+            {
+                var toRemove = _itemAttributes.Skills.Where(ss => ss.First().ItemSlot != ItemSlot.Unequipable).ToList();
+                foreach (var skills in toRemove)
+                {
+                    _itemAttributes.RemoveSkills(skills);
+                }
+            }
 
+            var import = JObject.Parse(importJson);
             if (importItems || importSkills)
             {
                 _itemAttributes.DeserializeItemsWithSkills(import, importItems, importSkills);
             }
-
             if (importLevel && import.TryGetValue("character", out var characterToken))
             {
                 Build.Level = characterToken.Value<int>("level");

--- a/WPFSKillTree/ViewModels/Import/ImportCharacterViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/ImportCharacterViewModel.cs
@@ -1,9 +1,9 @@
 ﻿using System.ComponentModel;
-using System.Diagnostics;
 using System.Windows.Input;
 using PoESkillTree.Common.ViewModels;
 using PoESkillTree.Localization;
 using PoESkillTree.Model.Builds;
+using PoESkillTree.Utils;
 
 namespace PoESkillTree.ViewModels.Import
 {
@@ -19,7 +19,7 @@ namespace PoESkillTree.ViewModels.Import
         }
 
         private RelayCommand? _openInBrowserCommand;
-        public ICommand OpenInBrowserCommand => _openInBrowserCommand ??= new RelayCommand(() => Process.Start(ItemsLink));
+        public ICommand OpenInBrowserCommand => _openInBrowserCommand ??= new RelayCommand(() => Util.OpenInBrowser(ItemsLink));
 
         public ImportCharacterViewModel(PoEBuild build)
         {

--- a/WPFSKillTree/ViewModels/Import/ImportCharacterViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/ImportCharacterViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 using System.Windows.Input;
 using PoESkillTree.Common.ViewModels;
 using PoESkillTree.Localization;
@@ -9,7 +11,36 @@ namespace PoESkillTree.ViewModels.Import
 {
     public class ImportCharacterViewModel : CloseableViewModel
     {
+        private readonly CurrentLeaguesViewModel _currentLeaguesViewModel;
+        private readonly AccountCharactersViewModel _accountCharactersViewModel;
+
         public PoEBuild Build { get; }
+
+        private bool _privateProfile;
+
+        public bool PrivateProfile
+        {
+            get => _privateProfile;
+            set => SetProperty(ref _privateProfile, value, () => OnPropertyChanged(nameof(PublicProfile)));
+        }
+
+        public bool PublicProfile => !PrivateProfile;
+
+        private NotifyingTask<IReadOnlyList<string>> _currentLeagues;
+
+        public NotifyingTask<IReadOnlyList<string>> CurrentLeagues
+        {
+            get => _currentLeagues;
+            private set => SetProperty(ref _currentLeagues, value);
+        }
+
+        private NotifyingTask<IReadOnlyList<AccountCharacterViewModel>> _accountCharacters;
+
+        public NotifyingTask<IReadOnlyList<AccountCharacterViewModel>> AccountCharacters
+        {
+            get => _accountCharacters;
+            private set => SetProperty(ref _accountCharacters, value);
+        }
 
         private string _itemsLink;
         public string ItemsLink
@@ -21,11 +52,15 @@ namespace PoESkillTree.ViewModels.Import
         private RelayCommand? _openInBrowserCommand;
         public ICommand OpenInBrowserCommand => _openInBrowserCommand ??= new RelayCommand(() => Util.OpenInBrowser(ItemsLink));
 
-        public ImportCharacterViewModel(PoEBuild build)
+        public ImportCharacterViewModel(PoEBuild build, CurrentLeaguesViewModel currentLeagues, AccountCharactersViewModel accountCharacters)
         {
+            _currentLeaguesViewModel = currentLeagues;
+            _accountCharactersViewModel = accountCharacters;
             DisplayName = L10n.Message("Import Character");
             Build = build;
             Build.PropertyChanged += BuildOnPropertyChanged;
+            _currentLeagues = _currentLeaguesViewModel[Build.Realm];
+            _accountCharacters = GetAccountCharacters();
             _itemsLink = CreateItemsLink();
         }
 
@@ -36,11 +71,37 @@ namespace PoESkillTree.ViewModels.Import
 
         private void BuildOnPropertyChanged(object sender, PropertyChangedEventArgs propertyChangedEventArgs)
         {
+            var propertyName = propertyChangedEventArgs.PropertyName;
+            if (propertyName == nameof(PoEBuild.Realm))
+            {
+                CurrentLeagues = _currentLeaguesViewModel[Build.Realm];
+            }
+
+            if (propertyName == nameof(PoEBuild.Realm) || propertyName == nameof(PoEBuild.AccountName) || propertyName == nameof(PoEBuild.League))
+            {
+                AccountCharacters = GetAccountCharacters();
+            }
+
             ItemsLink = CreateItemsLink();
             // Jewel data: http://www.pathofexile.com/character-window/get-passive-skills?reqData=0&character={0}&accountName={1}
         }
 
-        private string CreateItemsLink() =>
-            $"https://www.pathofexile.com/character-window/get-items?character={Build.CharacterName}&accountName={Build.AccountName}";
+        private NotifyingTask<IReadOnlyList<AccountCharacterViewModel>> GetAccountCharacters()
+        {
+            var task = _accountCharactersViewModel.Get(Build.Realm, Build.AccountName).Select(cs =>
+                cs.Where(c => string.IsNullOrEmpty(Build.League) || c.League == Build.League)
+                    .OrderBy(c => c.Name)
+                    .ToList());
+            return task;
+        }
+
+        private string CreateItemsLink()
+        {
+            var link =
+                $"https://www.pathofexile.com/character-window/get-items?realm={Build.Realm.ToGGGIdentifier()}&character={Build.CharacterName}";
+            if (!string.IsNullOrEmpty(Build.AccountName))
+                link += $"&accountName={Build.AccountName}";
+            return link;
+        }
     }
 }

--- a/WPFSKillTree/ViewModels/Import/ImportCharacterViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/ImportCharacterViewModel.cs
@@ -1,8 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Input;
+using NLog;
 using PoESkillTree.Common.ViewModels;
+using PoESkillTree.Controls.Dialogs;
 using PoESkillTree.Localization;
 using PoESkillTree.Model.Builds;
 using PoESkillTree.Utils;
@@ -11,6 +17,13 @@ namespace PoESkillTree.ViewModels.Import
 {
     public class ImportCharacterViewModel : CloseableViewModel
     {
+        private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+        private const string ItemsEndpoint = "https://www.pathofexile.com/character-window/get-items?";
+        private const string PassiveTreeEndpoint = "https://www.pathofexile.com/character-window/get-passive-skills?reqData=0";
+
+        private readonly HttpClient _httpClient;
+        private readonly IDialogCoordinator _dialogCoordinator;
         private readonly CurrentLeaguesViewModel _currentLeaguesViewModel;
         private readonly AccountCharactersViewModel _accountCharactersViewModel;
 
@@ -42,18 +55,56 @@ namespace PoESkillTree.ViewModels.Import
             private set => SetProperty(ref _accountCharacters, value);
         }
 
-        private string _itemsLink;
-        public string ItemsLink
+        private NotifyingTask<string?> _importItemsTask = NotifyingTask<string?>.FromResult(default);
+
+        public NotifyingTask<string?> ImportItemsTask
         {
-            get => _itemsLink;
-            private set => SetProperty(ref _itemsLink, value);
+            get => _importItemsTask;
+            private set => SetProperty(ref _importItemsTask, value);
         }
 
-        private RelayCommand? _openInBrowserCommand;
-        public ICommand OpenInBrowserCommand => _openInBrowserCommand ??= new RelayCommand(() => Util.OpenInBrowser(ItemsLink));
+        private NotifyingTask<string?> _importPassiveTreeTask = NotifyingTask<string?>.FromResult(default);
 
-        public ImportCharacterViewModel(PoEBuild build, CurrentLeaguesViewModel currentLeagues, AccountCharactersViewModel accountCharacters)
+        public NotifyingTask<string?> ImportPassiveTreeTask
         {
+            get => _importPassiveTreeTask;
+            private set => SetProperty(ref _importPassiveTreeTask, value);
+        }
+
+        private ICommand? _importItemsSkillsAndLevelCommand;
+        public ICommand ImportItemsSkillsAndLevelCommand =>
+            _importItemsSkillsAndLevelCommand ??= new AsyncRelayCommand(ImportItemsSkillsAndLevelAsync, CanImport);
+
+        private ICommand? _importItemsCommand;
+        public ICommand ImportItemsCommand =>
+            _importItemsCommand ??= new AsyncRelayCommand(ImportItemsAsync, CanImport);
+
+        private ICommand? _importSkillsCommand;
+        public ICommand ImportSkillsCommand =>
+            _importSkillsCommand ??= new AsyncRelayCommand(ImportSkillsAsync, CanImport);
+
+        private ICommand? _importLevelCommand;
+        public ICommand ImportILevelCommand =>
+            _importLevelCommand ??= new AsyncRelayCommand(ImportLevelAsync, CanImport);
+
+        private ICommand? _importPassiveTreeAndJewelsCommand;
+        public ICommand ImportPassiveTreeAndJewelsCommand =>
+            _importPassiveTreeAndJewelsCommand ??= new AsyncRelayCommand(ImportPassiveTreeAndJewelsAsync, CanImport);
+
+        private ICommand? _importPassiveTreeCommand;
+        public ICommand ImportPassiveTreeCommand =>
+            _importPassiveTreeCommand ??= new AsyncRelayCommand(ImportPassiveTreeAsync, CanImport);
+
+        private ICommand? _importJewelsCommand;
+        public ICommand ImportJewelsCommand =>
+            _importJewelsCommand ??= new AsyncRelayCommand(ImportJewelsAsync, CanImport);
+
+        public ImportCharacterViewModel(
+            HttpClient httpClient, IDialogCoordinator dialogCoordinator, PoEBuild build,
+            CurrentLeaguesViewModel currentLeagues, AccountCharactersViewModel accountCharacters)
+        {
+            _httpClient = httpClient;
+            _dialogCoordinator = dialogCoordinator;
             _currentLeaguesViewModel = currentLeagues;
             _accountCharactersViewModel = accountCharacters;
             DisplayName = L10n.Message("Import Character");
@@ -61,7 +112,6 @@ namespace PoESkillTree.ViewModels.Import
             Build.PropertyChanged += BuildOnPropertyChanged;
             _currentLeagues = _currentLeaguesViewModel[Build.Realm];
             _accountCharacters = GetAccountCharacters();
-            _itemsLink = CreateItemsLink();
         }
 
         protected override void OnClose()
@@ -81,9 +131,6 @@ namespace PoESkillTree.ViewModels.Import
             {
                 AccountCharacters = GetAccountCharacters();
             }
-
-            ItemsLink = CreateItemsLink();
-            // Jewel data: http://www.pathofexile.com/character-window/get-passive-skills?reqData=0&character={0}&accountName={1}
         }
 
         private NotifyingTask<IReadOnlyList<AccountCharacterViewModel>> GetAccountCharacters()
@@ -95,13 +142,105 @@ namespace PoESkillTree.ViewModels.Import
             return task;
         }
 
-        private string CreateItemsLink()
+        private bool CanImport() =>
+            !string.IsNullOrEmpty(Build.CharacterName) && (PrivateProfile || !string.IsNullOrEmpty(Build.AccountName));
+
+        // TODO import functionality
+        private async Task ImportItemsSkillsAndLevelAsync()
         {
-            var link =
-                $"https://www.pathofexile.com/character-window/get-items?realm={Build.Realm.ToGGGIdentifier()}&character={Build.CharacterName}";
+            var importJson = await RequestItemsAsync(L10n.Message("Import Items, Skills and Level"));
+            if (importJson is null)
+                return;
+        }
+
+        private async Task ImportItemsAsync()
+        {
+            var importJson = await RequestItemsAsync(L10n.Message("Import Items"));
+            if (importJson is null)
+                return;
+        }
+
+        private async Task ImportSkillsAsync()
+        {
+            var importJson = await RequestItemsAsync(L10n.Message("Import Skills"));
+            if (importJson is null)
+                return;
+        }
+
+        private async Task ImportLevelAsync()
+        {
+            var importJson = await RequestItemsAsync(L10n.Message("Import Level"));
+            if (importJson is null)
+                return;
+        }
+
+        private async Task ImportPassiveTreeAndJewelsAsync()
+        {
+            var importJson = await RequestPassiveTreeAsync(L10n.Message("Import Passive Tree and Jewels"));
+            if (importJson is null)
+                return;
+        }
+
+        private async Task ImportPassiveTreeAsync()
+        {
+            var importJson = await RequestPassiveTreeAsync(L10n.Message("Import Passive Tree"));
+            if (importJson is null)
+                return;
+        }
+
+        private async Task ImportJewelsAsync()
+        {
+            var importJson = await RequestPassiveTreeAsync(L10n.Message("Import Jewels"));
+            if (importJson is null)
+                return;
+        }
+
+        private async Task<string?> RequestItemsAsync(string title)
+        {
+            ImportItemsTask = new NotifyingTask<string?>(RequestAsync(ItemsUrl, title),
+                e => Log.Error($"Could not retrieve {ItemsUrl}"));
+            await ImportItemsTask.TaskCompletion;
+            return ImportItemsTask.IsSuccessfullyCompleted ? ImportItemsTask.Result : null;
+        }
+
+        private async Task<string?> RequestPassiveTreeAsync(string title)
+        {
+            ImportPassiveTreeTask = new NotifyingTask<string?>(RequestAsync(PassiveTreeUrl, title),
+                e => Log.Error($"Could not retrieve {PassiveTreeUrl}"));
+            await ImportPassiveTreeTask.TaskCompletion;
+            return ImportPassiveTreeTask.IsSuccessfullyCompleted ? ImportPassiveTreeTask.Result : null;
+        }
+
+        private async Task<string?> RequestAsync(string url, string title)
+        {
+            if (PrivateProfile)
+            {
+                var message = L10n.Message("A tab in your default web browser has been opened containing your character's data.") + "\n"
+                    + L10n.Message("Copy its contents and paste them into the field below.") + "\n"
+                    + L10n.Message("In case no browser has been opened, the URL was also copied to your clipboard.");
+                var task = _dialogCoordinator.ShowInputAsync(this, title, message);
+                Clipboard.SetText(url);
+                await Task.Delay(TimeSpan.FromMilliseconds(200));
+                Util.OpenInBrowser(url);
+                return await task;
+            }
+            else
+            {
+                var result = await _httpClient.GetAsync(url);
+                result.EnsureSuccessStatusCode();
+                return await result.Content.ReadAsStringAsync();
+            }
+        }
+
+        private string ItemsUrl => ItemsEndpoint + GetQueryString();
+        private string PassiveTreeUrl => PassiveTreeEndpoint + GetQueryString();
+
+        private string GetQueryString()
+        {
+            var query = $"realm={Build.Realm.ToGGGIdentifier()}&character={Build.CharacterName}";
             if (!string.IsNullOrEmpty(Build.AccountName))
-                link += $"&accountName={Build.AccountName}";
-            return link;
+                query += $"&accountName={Build.AccountName}";
+            return query;
         }
     }
 }

--- a/WPFSKillTree/ViewModels/Import/ImportCharacterViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/ImportCharacterViewModel.cs
@@ -5,7 +5,7 @@ using PoESkillTree.Common.ViewModels;
 using PoESkillTree.Localization;
 using PoESkillTree.Model.Builds;
 
-namespace PoESkillTree.ViewModels.Equipment
+namespace PoESkillTree.ViewModels.Import
 {
     public class ImportCharacterViewModel : CloseableViewModel
     {

--- a/WPFSKillTree/ViewModels/Import/ImportStashViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/ImportStashViewModel.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Data;
@@ -25,9 +23,9 @@ namespace PoESkillTree.ViewModels.Import
     public class ImportStashViewModel : CloseableViewModel
     {
         private readonly StashViewModel _stash;
+        private readonly CurrentLeaguesViewModel _currentLeaguesViewModel;
         private readonly IPersistentData _persistentData;
         private readonly IDialogCoordinator _dialogCoordinator;
-        private readonly TaskCompletionSource<object?> _viewLoadedCompletionSource;
 
         public PoEBuild Build { get; }
 
@@ -49,12 +47,18 @@ namespace PoESkillTree.ViewModels.Import
 
         public ICollectionView TabsView { get; }
 
-        public static NotifyingTask<IReadOnlyList<string>>? CurrentLeagues { get; private set; }
+        private NotifyingTask<IReadOnlyList<string>> _currentLeagues;
+
+        public NotifyingTask<IReadOnlyList<string>> CurrentLeagues
+        {
+            get => _currentLeagues;
+            private set => SetProperty(ref _currentLeagues, value);
+        }
 
         private RelayCommand<string>? _openInBrowserCommand;
 
         public ICommand OpenInBrowserCommand => _openInBrowserCommand ??= new RelayCommand<string>(
-            param => Process.Start(param),
+            Util.OpenInBrowser,
             param => !string.IsNullOrEmpty(param));
 
         private ICommand? _loadTabsCommand;
@@ -64,13 +68,16 @@ namespace PoESkillTree.ViewModels.Import
         public ICommand LoadTabContentsCommand => _loadTabContentsCommand ??= new AsyncRelayCommand(LoadTabContents);
 
         public ImportStashViewModel(
-            IDialogCoordinator dialogCoordinator, IPersistentData persistentData, StashViewModel stash)
+            IDialogCoordinator dialogCoordinator, IPersistentData persistentData, StashViewModel stash, CurrentLeaguesViewModel currentLeagues)
         {
             _stash = stash;
+            _currentLeaguesViewModel = currentLeagues;
             _persistentData = persistentData;
             _dialogCoordinator = dialogCoordinator;
             DisplayName = L10n.Message("Download & Import Stash");
             Build = persistentData.CurrentBuild;
+
+            _currentLeagues = _currentLeaguesViewModel[Build.Realm];
 
             if (Build.League != null && _persistentData.LeagueStashes.ContainsKey(Build.League))
                 _tabs = new List<StashBookmark>(_persistentData.LeagueStashes[Build.League]);
@@ -80,33 +87,6 @@ namespace PoESkillTree.ViewModels.Import
             _tabsLink = CreateTabsLink();
             _tabLink = CreateTabLink();
             Build.PropertyChanged += BuildOnPropertyChanged;
-
-            _viewLoadedCompletionSource = new TaskCompletionSource<object?>();
-            if (CurrentLeagues == null)
-            {
-                CurrentLeagues = new NotifyingTask<IReadOnlyList<string>>(LoadCurrentLeaguesAsync(),
-                    async e =>
-                    {
-                        await _viewLoadedCompletionSource.Task;
-                        await _dialogCoordinator.ShowWarningAsync(this,
-                            L10n.Message("Could not load the currently running leagues."), e.Message);
-                    });
-            }
-        }
-
-        // Errors in CurrentLeagues task may only be shown when the dialog coordinator context is registered,
-        // which requires the view to be loaded.
-        public void ViewLoaded()
-        {
-            _viewLoadedCompletionSource.SetResult(null);
-        }
-
-        private static async Task<IReadOnlyList<string>> LoadCurrentLeaguesAsync()
-        {
-            using var client = new HttpClient();
-            var file = await client.GetStringAsync("http://api.pathofexile.com/leagues?type=main&compact=1")
-                .ConfigureAwait(false);
-            return JArray.Parse(file).Select(t => Extensions.Value<string>(t["id"]!)).ToList();
         }
 
         protected override void OnClose()
@@ -116,7 +96,7 @@ namespace PoESkillTree.ViewModels.Import
 
         private void BuildOnPropertyChanged(object sender, PropertyChangedEventArgs propertyChangedEventArgs)
         {
-            if (propertyChangedEventArgs.PropertyName == "League")
+            if (propertyChangedEventArgs.PropertyName == nameof(PoEBuild.League))
             {
                 _tabs.Clear();
                 if (Build.League != null && _persistentData.LeagueStashes.ContainsKey(Build.League))
@@ -126,12 +106,16 @@ namespace PoESkillTree.ViewModels.Import
                 TabsView.Refresh();
                 TabsView.MoveCurrentToFirst();
             }
+            else if (propertyChangedEventArgs.PropertyName == nameof(PoEBuild.Realm))
+            {
+                CurrentLeagues = _currentLeaguesViewModel[Build.Realm];
+            }
             TabsLink = CreateTabsLink();
             UpdateTabLink();
         }
 
         private string CreateTabsLink() =>
-            $"https://www.pathofexile.com/character-window/get-stash-items?tabs=1&tabIndex=0&league={Build.League}&accountName={Build.AccountName}";
+            $"https://www.pathofexile.com/character-window/get-stash-items?tabs=1&tabIndex=0&realm={Build.Realm.ToGGGIdentifier()}&league={Build.League}&accountName={Build.AccountName}";
 
         private void UpdateTabLink()
         {
@@ -140,7 +124,7 @@ namespace PoESkillTree.ViewModels.Import
 
         private string CreateTabLink() =>
             TabsView.CurrentItem is StashBookmark selectedTab
-                ? $"https://www.pathofexile.com/character-window/get-stash-items?tabs=0&tabIndex={selectedTab.Position}&league={Build.League}&accountName={Build.AccountName}"
+                ? $"https://www.pathofexile.com/character-window/get-stash-items?tabs=0&tabIndex={selectedTab.Position}&realm={Build.Realm.ToGGGIdentifier()}&league={Build.League}&accountName={Build.AccountName}"
                 : "";
 
         private async Task LoadTabs()

--- a/WPFSKillTree/ViewModels/Import/ImportStashViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/ImportStashViewModel.cs
@@ -10,7 +10,6 @@ using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
 using Newtonsoft.Json.Linq;
-using PoESkillTree.Utils;
 using PoESkillTree.Common.ViewModels;
 using PoESkillTree.Controls;
 using PoESkillTree.Controls.Dialogs;
@@ -18,8 +17,10 @@ using PoESkillTree.Localization;
 using PoESkillTree.Model;
 using PoESkillTree.Model.Builds;
 using PoESkillTree.Model.Items;
+using PoESkillTree.Utils;
+using PoESkillTree.ViewModels.Equipment;
 
-namespace PoESkillTree.ViewModels.Equipment
+namespace PoESkillTree.ViewModels.Import
 {
     public class ImportStashViewModel : CloseableViewModel
     {
@@ -105,7 +106,7 @@ namespace PoESkillTree.ViewModels.Equipment
             using var client = new HttpClient();
             var file = await client.GetStringAsync("http://api.pathofexile.com/leagues?type=main&compact=1")
                 .ConfigureAwait(false);
-            return JArray.Parse(file).Select(t => t["id"]!.Value<string>()).ToList();
+            return JArray.Parse(file).Select(t => Extensions.Value<string>(t["id"]!)).ToList();
         }
 
         protected override void OnClose()

--- a/WPFSKillTree/ViewModels/Import/ImportViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/ImportViewModel.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Net.Http;
+using PoESkillTree.Controls.Dialogs;
+using PoESkillTree.Model;
+using PoESkillTree.ViewModels.Equipment;
+
+namespace PoESkillTree.ViewModels.Import
+{
+    public class ImportViewModels
+    {
+        private readonly IDialogCoordinator _dialogCoordinator;
+        private readonly IPersistentData _persistentData;
+        private readonly StashViewModel _stash;
+        private readonly Lazy<CurrentLeaguesViewModel> _currentLeagues;
+
+        public ImportViewModels(IDialogCoordinator dialogCoordinator, IPersistentData persistentData, StashViewModel stash)
+        {
+            _dialogCoordinator = dialogCoordinator;
+            _persistentData = persistentData;
+            _stash = stash;
+            var httpClient = new HttpClient();
+            _currentLeagues = new Lazy<CurrentLeaguesViewModel>(() => new CurrentLeaguesViewModel(dialogCoordinator, httpClient));
+        }
+
+        public CurrentLeaguesViewModel CurrentLeagues => _currentLeagues.Value;
+        public ImportCharacterViewModel ImportCharacter => new ImportCharacterViewModel(_persistentData.CurrentBuild);
+        public ImportStashViewModel ImportStash => new ImportStashViewModel(_dialogCoordinator, _persistentData, _stash, CurrentLeagues);
+    }
+}

--- a/WPFSKillTree/ViewModels/Import/ImportViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/ImportViewModel.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using PoESkillTree.Controls.Dialogs;
 using PoESkillTree.Model;
 using PoESkillTree.Model.Items;
+using PoESkillTree.SkillTreeFiles;
 using PoESkillTree.ViewModels.Equipment;
 
 namespace PoESkillTree.ViewModels.Import
@@ -27,9 +28,9 @@ namespace PoESkillTree.ViewModels.Import
             _accountCharacters = new Lazy<AccountCharactersViewModel>(() => new AccountCharactersViewModel(_httpClient));
         }
 
-        public ImportCharacterViewModel ImportCharacter(ItemAttributes itemAttributes) =>
-            new ImportCharacterViewModel(_httpClient, _dialogCoordinator, itemAttributes, _persistentData.CurrentBuild, _currentLeagues.Value,
-                _accountCharacters.Value);
+        public ImportCharacterViewModel ImportCharacter(ItemAttributes itemAttributes, SkillTree skillTree) =>
+            new ImportCharacterViewModel(_httpClient, _dialogCoordinator, itemAttributes, skillTree, _persistentData.CurrentBuild,
+                _currentLeagues.Value, _accountCharacters.Value);
 
         public ImportStashViewModel ImportStash => new ImportStashViewModel(_dialogCoordinator, _persistentData, _stash, _currentLeagues.Value);
     }

--- a/WPFSKillTree/ViewModels/Import/ImportViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/ImportViewModel.cs
@@ -12,6 +12,7 @@ namespace PoESkillTree.ViewModels.Import
         private readonly IPersistentData _persistentData;
         private readonly StashViewModel _stash;
         private readonly Lazy<CurrentLeaguesViewModel> _currentLeagues;
+        private readonly Lazy<AccountCharactersViewModel> _accountCharacters;
 
         public ImportViewModels(IDialogCoordinator dialogCoordinator, IPersistentData persistentData, StashViewModel stash)
         {
@@ -19,11 +20,13 @@ namespace PoESkillTree.ViewModels.Import
             _persistentData = persistentData;
             _stash = stash;
             var httpClient = new HttpClient();
-            _currentLeagues = new Lazy<CurrentLeaguesViewModel>(() => new CurrentLeaguesViewModel(dialogCoordinator, httpClient));
+            _currentLeagues = new Lazy<CurrentLeaguesViewModel>(() => new CurrentLeaguesViewModel(httpClient));
+            _accountCharacters = new Lazy<AccountCharactersViewModel>(() => new AccountCharactersViewModel(httpClient));
         }
 
-        public CurrentLeaguesViewModel CurrentLeagues => _currentLeagues.Value;
-        public ImportCharacterViewModel ImportCharacter => new ImportCharacterViewModel(_persistentData.CurrentBuild);
-        public ImportStashViewModel ImportStash => new ImportStashViewModel(_dialogCoordinator, _persistentData, _stash, CurrentLeagues);
+        public ImportCharacterViewModel ImportCharacter =>
+            new ImportCharacterViewModel(_persistentData.CurrentBuild, _currentLeagues.Value, _accountCharacters.Value);
+
+        public ImportStashViewModel ImportStash => new ImportStashViewModel(_dialogCoordinator, _persistentData, _stash, _currentLeagues.Value);
     }
 }

--- a/WPFSKillTree/ViewModels/Import/ImportViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/ImportViewModel.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using PoESkillTree.Controls.Dialogs;
 using PoESkillTree.Model;
+using PoESkillTree.Model.Items;
 using PoESkillTree.ViewModels.Equipment;
 
 namespace PoESkillTree.ViewModels.Import
@@ -15,7 +16,8 @@ namespace PoESkillTree.ViewModels.Import
         private readonly Lazy<CurrentLeaguesViewModel> _currentLeagues;
         private readonly Lazy<AccountCharactersViewModel> _accountCharacters;
 
-        public ImportViewModels(IDialogCoordinator dialogCoordinator, IPersistentData persistentData, StashViewModel stash)
+        public ImportViewModels(
+            IDialogCoordinator dialogCoordinator, IPersistentData persistentData, StashViewModel stash)
         {
             _dialogCoordinator = dialogCoordinator;
             _persistentData = persistentData;
@@ -25,8 +27,8 @@ namespace PoESkillTree.ViewModels.Import
             _accountCharacters = new Lazy<AccountCharactersViewModel>(() => new AccountCharactersViewModel(_httpClient));
         }
 
-        public ImportCharacterViewModel ImportCharacter =>
-            new ImportCharacterViewModel(_httpClient, _dialogCoordinator, _persistentData.CurrentBuild, _currentLeagues.Value,
+        public ImportCharacterViewModel ImportCharacter(ItemAttributes itemAttributes) =>
+            new ImportCharacterViewModel(_httpClient, _dialogCoordinator, itemAttributes, _persistentData.CurrentBuild, _currentLeagues.Value,
                 _accountCharacters.Value);
 
         public ImportStashViewModel ImportStash => new ImportStashViewModel(_dialogCoordinator, _persistentData, _stash, _currentLeagues.Value);

--- a/WPFSKillTree/ViewModels/Import/ImportViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/ImportViewModel.cs
@@ -11,6 +11,7 @@ namespace PoESkillTree.ViewModels.Import
         private readonly IDialogCoordinator _dialogCoordinator;
         private readonly IPersistentData _persistentData;
         private readonly StashViewModel _stash;
+        private readonly HttpClient _httpClient;
         private readonly Lazy<CurrentLeaguesViewModel> _currentLeagues;
         private readonly Lazy<AccountCharactersViewModel> _accountCharacters;
 
@@ -19,13 +20,14 @@ namespace PoESkillTree.ViewModels.Import
             _dialogCoordinator = dialogCoordinator;
             _persistentData = persistentData;
             _stash = stash;
-            var httpClient = new HttpClient();
-            _currentLeagues = new Lazy<CurrentLeaguesViewModel>(() => new CurrentLeaguesViewModel(httpClient));
-            _accountCharacters = new Lazy<AccountCharactersViewModel>(() => new AccountCharactersViewModel(httpClient));
+            _httpClient = new HttpClient();
+            _currentLeagues = new Lazy<CurrentLeaguesViewModel>(() => new CurrentLeaguesViewModel(_httpClient));
+            _accountCharacters = new Lazy<AccountCharactersViewModel>(() => new AccountCharactersViewModel(_httpClient));
         }
 
         public ImportCharacterViewModel ImportCharacter =>
-            new ImportCharacterViewModel(_persistentData.CurrentBuild, _currentLeagues.Value, _accountCharacters.Value);
+            new ImportCharacterViewModel(_httpClient, _dialogCoordinator, _persistentData.CurrentBuild, _currentLeagues.Value,
+                _accountCharacters.Value);
 
         public ImportStashViewModel ImportStash => new ImportStashViewModel(_dialogCoordinator, _persistentData, _stash, _currentLeagues.Value);
     }

--- a/WPFSKillTree/Views/Equipment/ImportCharacterWindow.xaml
+++ b/WPFSKillTree/Views/Equipment/ImportCharacterWindow.xaml
@@ -1,5 +1,5 @@
 ﻿<dialogs:CloseableBaseDialog
-    x:Class="PoESkillTree.Views.Equipment.DownloadItemsWindow"
+    x:Class="PoESkillTree.Views.Equipment.ImportCharacterWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:l="clr-namespace:PoESkillTree.Localization.XAML"
@@ -8,7 +8,7 @@
     xmlns:metroControls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
     xmlns:dialogs="clr-namespace:PoESkillTree.Controls.Dialogs"
     xmlns:viewModels="clr-namespace:PoESkillTree.ViewModels.Equipment"
-    d:DataContext="{d:DesignInstance viewModels:DownloadItemsViewModel}">
+    d:DataContext="{d:DesignInstance viewModels:ImportCharacterViewModel}">
     <StackPanel>
         <TextBlock Margin="5" TextWrapping="Wrap">
             <l:Catalog Message="Please enter your Character and Account Name below and click 'Open in Browser'."/><LineBreak/>
@@ -38,7 +38,7 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <Label HorizontalAlignment="Left">
-                <l:Catalog Message="Link to item data:"/>
+                <l:Catalog Message="Link to item and skill data:"/>
             </Label>
             <Button Grid.Column="1"
                     Command="{Binding OpenInBrowserCommand}">
@@ -49,7 +49,7 @@
                  Text="{Binding ItemsLink, Mode=OneWay}" IsReadOnly="True"/>
 
         <Label HorizontalAlignment="Left" Margin="5,5,0,0">
-            <l:Catalog Message="Item data:"/>
+            <l:Catalog Message="Item and skill data:"/>
         </Label>
         <TextBox Margin="5" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"
                  AcceptsTab="True" AcceptsReturn="True" MaxLines="6"

--- a/WPFSKillTree/Views/Equipment/ImportCharacterWindow.xaml.cs
+++ b/WPFSKillTree/Views/Equipment/ImportCharacterWindow.xaml.cs
@@ -1,11 +1,11 @@
 ﻿namespace PoESkillTree.Views.Equipment
 {
     /// <summary>
-    /// Interaction logic for DownloadItemsWindow.xaml
+    /// Interaction logic for ImportCharacterWindow.xaml
     /// </summary>
-    public partial class DownloadItemsWindow
+    public partial class ImportCharacterWindow
     {
-        public DownloadItemsWindow()
+        public ImportCharacterWindow()
         {
             InitializeComponent();
         }

--- a/WPFSKillTree/Views/Equipment/ImportStashWindow.xaml
+++ b/WPFSKillTree/Views/Equipment/ImportStashWindow.xaml
@@ -1,5 +1,5 @@
 ﻿<dialogs:CloseableBaseDialog
-    x:Class="PoESkillTree.Views.Equipment.DownloadStashWindow"
+    x:Class="PoESkillTree.Views.Equipment.ImportStashWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:l="clr-namespace:PoESkillTree.Localization.XAML"
@@ -8,7 +8,7 @@
     xmlns:metroControls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
     xmlns:dialogs="clr-namespace:PoESkillTree.Controls.Dialogs"
     xmlns:viewModels="clr-namespace:PoESkillTree.ViewModels.Equipment"
-    d:DataContext="{d:DesignInstance viewModels:DownloadStashViewModel}">
+    d:DataContext="{d:DesignInstance viewModels:ImportStashViewModel}">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />

--- a/WPFSKillTree/Views/Equipment/ImportStashWindow.xaml.cs
+++ b/WPFSKillTree/Views/Equipment/ImportStashWindow.xaml.cs
@@ -1,11 +1,11 @@
 ﻿namespace PoESkillTree.Views.Equipment
 {
     /// <summary>
-    /// Interaction logic for DownloadItemsWindow.xaml
+    /// Interaction logic for ImportStashWindow.xaml
     /// </summary>
-    public partial class DownloadStashWindow
+    public partial class ImportStashWindow
     {
-        public DownloadStashWindow()
+        public ImportStashWindow()
         {
             InitializeComponent();
         }

--- a/WPFSKillTree/Views/HotkeysWindow.xaml.cs
+++ b/WPFSKillTree/Views/HotkeysWindow.xaml.cs
@@ -1,7 +1,7 @@
 ﻿namespace PoESkillTree.Views
 {
     /// <summary>
-    /// Interaction logic for DownloadItemsWindow.xaml
+    /// Interaction logic for HotkeysWindow.xaml
     /// </summary>
     public partial class HotkeysWindow
     {

--- a/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml
+++ b/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml
@@ -1,5 +1,5 @@
 ﻿<dialogs:CloseableBaseDialog
-    x:Class="PoESkillTree.Views.Equipment.ImportCharacterWindow"
+    x:Class="PoESkillTree.Views.Import.ImportCharacterWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:l="clr-namespace:PoESkillTree.Localization.XAML"
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d"
     xmlns:metroControls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
     xmlns:dialogs="clr-namespace:PoESkillTree.Controls.Dialogs"
-    xmlns:viewModels="clr-namespace:PoESkillTree.ViewModels.Equipment"
+    xmlns:viewModels="clr-namespace:PoESkillTree.ViewModels.Import"
     d:DataContext="{d:DesignInstance viewModels:ImportCharacterViewModel}">
     <StackPanel>
         <TextBlock Margin="5" TextWrapping="Wrap">

--- a/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml
+++ b/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml
@@ -130,6 +130,7 @@
                       StaysOpenOnEdit="True"
                       TextSearch.TextPath="Name"
                       Text="{Binding Build.CharacterName}"
+                      SelectedItem="{Binding SelectedAccountCharacter}"
                       ItemsSource="{Binding AccountCharacters.Result}">
                 <metroControls:TextBoxHelper.Watermark>
                     <l:Catalog Message="Character name"/>

--- a/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml
+++ b/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml
@@ -1,4 +1,4 @@
-﻿<dialogs:CloseableBaseDialog
+<dialogs:CloseableBaseDialog
     x:Class="PoESkillTree.Views.Import.ImportCharacterWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -10,7 +10,7 @@
     xmlns:viewModels="clr-namespace:PoESkillTree.ViewModels.Import"
     xmlns:builds="clr-namespace:PoESkillTree.Model.Builds"
     xmlns:wpf="clr-namespace:PoESkillTree.Utils.Wpf"
-    MinContentWidth="400" MaxContentWidth="800"
+    MinContentWidth="500" MaxContentWidth="650"
     d:DataContext="{d:DesignInstance viewModels:ImportCharacterViewModel}">
     <dialogs:CloseableBaseDialog.Resources>
         <Style x:Key="FaultedTaskBorderStyle"
@@ -30,10 +30,10 @@
             <Setter Property="Margin" Value="0 5 0 0" />
         </Style>
     </dialogs:CloseableBaseDialog.Resources>
+
     <dialogs:CloseableBaseDialog.DialogLeft>
         <StackPanel HorizontalAlignment="Right"
-                    Margin="10 50 10 0"
-                    Visibility="{Binding PublicProfile, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Margin="10 15 10 0">
             <Border Visibility="{Binding CurrentLeagues.IsFaulted, Converter={StaticResource BooleanToVisibilityConverter}}"
                     Style="{StaticResource FaultedTaskBorderStyle}">
                 <TextBlock Foreground="{DynamicResource MahApps.Brushes.Text.Validation}">
@@ -48,34 +48,58 @@
                     <l:Catalog Message="Retrieving leagues for realm…"/>
                 </Label>
             </Border>
-            <Border Visibility="{Binding AccountCharacters.IsFaulted, Converter={StaticResource BooleanToVisibilityConverter}}"
+
+            <Grid Visibility="{Binding PublicProfile, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Border Visibility="{Binding AccountCharacters.IsFaulted, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        Style="{StaticResource FaultedTaskBorderStyle}">
+                    <TextBlock Foreground="{DynamicResource MahApps.Brushes.Text.Validation}">
+                        <Run><Run.Text><l:Catalog Message="Retrieving characters for account failed:"/></Run.Text></Run>
+                        <LineBreak />
+                        <Run Text="{Binding AccountCharacters.ErrorMessage, Mode=OneWay}" />
+                    </TextBlock>
+                </Border>
+                <Border Visibility="{Binding AccountCharacters.IsNotCompleted, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        Style="{StaticResource NotCompletedTaskBorderStyle}">
+                    <Label>
+                        <l:Catalog Message="Retrieving characters for account…"/>
+                    </Label>
+                </Border>
+            </Grid>
+
+            <Border Visibility="{Binding ImportItemsTask.IsFaulted, Converter={StaticResource BooleanToVisibilityConverter}}"
                     Style="{StaticResource FaultedTaskBorderStyle}">
                 <TextBlock Foreground="{DynamicResource MahApps.Brushes.Text.Validation}">
-                    <Run><Run.Text><l:Catalog Message="Retrieving characters for account failed:"/></Run.Text></Run>
+                    <Run><Run.Text><l:Catalog Message="Importing item and skill data failed:"/></Run.Text></Run>
                     <LineBreak />
-                    <Run Text="{Binding AccountCharacters.ErrorMessage, Mode=OneWay}" />
+                    <Run Text="{Binding ImportItemsTask.ErrorMessage, Mode=OneWay}" />
                 </TextBlock>
             </Border>
-            <Border Visibility="{Binding AccountCharacters.IsNotCompleted, Converter={StaticResource BooleanToVisibilityConverter}}"
+            <Border Visibility="{Binding ImportItemsTask.IsNotCompleted, Converter={StaticResource BooleanToVisibilityConverter}}"
                     Style="{StaticResource NotCompletedTaskBorderStyle}">
                 <Label>
-                    <l:Catalog Message="Retrieving characters for account…"/>
+                    <l:Catalog Message="Importing item and skill data…"/>
+                </Label>
+            </Border>
+
+            <Border Visibility="{Binding ImportPassiveTreeTask.IsFaulted, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Style="{StaticResource FaultedTaskBorderStyle}">
+                <TextBlock Foreground="{DynamicResource MahApps.Brushes.Text.Validation}">
+                    <Run><Run.Text><l:Catalog Message="Importing passive tree and jewel data failed:"/></Run.Text></Run>
+                    <LineBreak />
+                    <Run Text="{Binding ImportPassiveTreeTask.ErrorMessage, Mode=OneWay}" />
+                </TextBlock>
+            </Border>
+            <Border Visibility="{Binding ImportPassiveTreeTask.IsNotCompleted, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Style="{StaticResource NotCompletedTaskBorderStyle}">
+                <Label>
+                    <l:Catalog Message="Importing passive tree and jewel data data…"/>
                 </Label>
             </Border>
         </StackPanel>
     </dialogs:CloseableBaseDialog.DialogLeft>
-    <StackPanel>
-        <metroControls:ToggleSwitch IsChecked="{Binding PrivateProfile}"
-                                    HorizontalAlignment="Right">
-            <metroControls:ToggleSwitch.OnLabel>
-                <l:Catalog Message="Profile is private" />
-            </metroControls:ToggleSwitch.OnLabel>
-            <metroControls:ToggleSwitch.OffLabel>
-                <l:Catalog Message="Profile is not private" />
-            </metroControls:ToggleSwitch.OffLabel>
-        </metroControls:ToggleSwitch>
 
-        <UniformGrid Margin="0 3"
+    <StackPanel>
+        <UniformGrid Margin="0 5"
                      Columns="4">
             <ComboBox Margin="0"
                       Text="{Binding Build.Realm}"
@@ -96,7 +120,7 @@
                       IsEditable="True"
                       ItemsSource="{Binding CurrentLeagues.Result}">
                 <metroControls:TextBoxHelper.Watermark>
-                    <l:Catalog Message="League"/>
+                    <l:Catalog Message="All leagues"/>
                 </metroControls:TextBoxHelper.Watermark>
             </ComboBox>
             <ComboBox Margin="5 0 0 0"
@@ -122,37 +146,59 @@
             </ComboBox>
         </UniformGrid>
 
-        <TextBlock Margin="0 3" TextWrapping="Wrap">
-            <l:Catalog Message="Please enter your Character and Account Name below and click 'Open in Browser'."/><LineBreak/>
-            <l:Catalog Message="This will open a page in your default Web-Browser containing your character's item data"/><LineBreak/>
-            <l:Catalog Message="Copy the contents of that page and paste them into the 'Item data' field."/>
-        </TextBlock>
+        <CheckBox IsChecked="{Binding PrivateProfile}"
+                  Margin="0 5">
+            <l:Catalog Message="Profile is private" />
+        </CheckBox>
 
-        <Grid Margin="0 3 0 0">
+        <Grid>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="1*" />
             </Grid.ColumnDefinitions>
-            <Label HorizontalAlignment="Left">
-                <l:Catalog Message="Link to item and skill data:"/>
-            </Label>
-            <Button Grid.Column="1"
-                    Command="{Binding OpenInBrowserCommand}">
-                <l:Catalog Message="Open in Browser"/>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="1*" />
+                <RowDefinition Height="1*" />
+            </Grid.RowDefinitions>
+
+            <Button Grid.Column="0" Grid.Row="0"
+                    Margin="0 5 0 5"
+                    Command="{Binding ImportItemsSkillsAndLevelCommand}">
+                <l:Catalog Message="Import items, skills and level" />
+            </Button>
+            <Button Grid.Column="1" Grid.Row="0"
+                    Margin="5 5 0 5"
+                    Command="{Binding ImportItemsCommand}">
+                <l:Catalog Message="Import items" />
+            </Button>
+            <Button Grid.Column="2" Grid.Row="0"
+                    Margin="5 5 0 5"
+                    Command="{Binding ImportSkillsCommand}">
+                <l:Catalog Message="Import skills" />
+            </Button>
+            <Button Grid.Column="3" Grid.Row="0"
+                    Margin="5 5 0 5"
+                    Command="{Binding ImportILevelCommand}">
+                <l:Catalog Message="Import level" />
+            </Button>
+
+            <Button Grid.Column="0" Grid.Row="1"
+                    Margin="0 5 0 0"
+                    Command="{Binding ImportPassiveTreeAndJewelsCommand}">
+                <l:Catalog Message="Import passive tree and jewels" />
+            </Button>
+            <Button Grid.Column="1" Grid.Row="1"
+                    Margin="5 5 0 0"
+                    Command="{Binding ImportPassiveTreeCommand}">
+                <l:Catalog Message="Import tree" />
+            </Button>
+            <Button Grid.Column="2" Grid.Row="1"
+                    Margin="5 5 0 0"
+                    Command="{Binding ImportJewelsCommand}">
+                <l:Catalog Message="Import jewels" />
             </Button>
         </Grid>
-        <TextBox Margin="0 3" TextWrapping="Wrap"
-                 MaxLines="1"
-                 VerticalScrollBarVisibility="Auto"
-                 Text="{Binding ItemsLink, Mode=OneWay}" IsReadOnly="True"/>
-
-        <Label HorizontalAlignment="Left" Margin="0 3 0 0">
-            <l:Catalog Message="Item and skill data:"/>
-        </Label>
-        <TextBox Margin="0" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"
-                 AcceptsTab="True" AcceptsReturn="True" MaxLines="6"
-                 metroControls:TextBoxHelper.ClearTextButton="True"
-                 metroControls:TextBoxHelper.SelectAllOnFocus="True"
-                 Text="{Binding Build.ItemData}" />
     </StackPanel>
 </dialogs:CloseableBaseDialog>

--- a/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml
+++ b/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml
@@ -8,31 +8,91 @@
     xmlns:metroControls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
     xmlns:dialogs="clr-namespace:PoESkillTree.Controls.Dialogs"
     xmlns:viewModels="clr-namespace:PoESkillTree.ViewModels.Import"
+    xmlns:builds="clr-namespace:PoESkillTree.Model.Builds"
+    xmlns:wpf="clr-namespace:PoESkillTree.Utils.Wpf"
+    MinContentWidth="400" MaxContentWidth="800"
     d:DataContext="{d:DesignInstance viewModels:ImportCharacterViewModel}">
+    <dialogs:CloseableBaseDialog.DialogLeft>
+        <StackPanel HorizontalAlignment="Right"
+                    Margin="5 80 5 0"
+                    Visibility="{Binding PublicProfile, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Border Visibility="{Binding AccountCharacters.IsFaulted, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Background="{DynamicResource MahApps.Brushes.Validation5}"
+                    CornerRadius="2">
+                <TextBlock Foreground="{DynamicResource MahApps.Brushes.Text.Validation}"
+                           Margin="4 2">
+                    <Run><Run.Text><l:Catalog Message="Retrieving characters for account failed:"/></Run.Text></Run>
+                    <LineBreak />
+                    <Run Text="{Binding AccountCharacters.ErrorMessage, Mode=OneWay}" />
+                </TextBlock>
+            </Border>
+        </StackPanel>
+    </dialogs:CloseableBaseDialog.DialogLeft>
     <StackPanel>
-        <TextBlock Margin="5" TextWrapping="Wrap">
-            <l:Catalog Message="Please enter your Character and Account Name below and click 'Open in Browser'."/><LineBreak/>
-            <l:Catalog Message="This will open a page in your default Web-Browser containing your character's item data"/><LineBreak/>
-            <l:Catalog Message="Copy the contents of that page and paste them into the 'Item data' field."/>
-        </TextBlock>
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
-            <TextBox Margin="5,5,2,5" MaxLength="24" Text="{Binding Build.CharacterName}">
+        <metroControls:ToggleSwitch IsChecked="{Binding PrivateProfile}"
+                                    HorizontalAlignment="Right">
+            <metroControls:ToggleSwitch.OnLabel>
+                <l:Catalog Message="Profile is private" />
+            </metroControls:ToggleSwitch.OnLabel>
+            <metroControls:ToggleSwitch.OffLabel>
+                <l:Catalog Message="Profile is not private" />
+            </metroControls:ToggleSwitch.OffLabel>
+        </metroControls:ToggleSwitch>
+
+        <UniformGrid Margin="0 3"
+                     Columns="4">
+            <ComboBox Margin="0"
+                      Text="{Binding Build.Realm}"
+                      ItemsSource="{Binding Source={wpf:EnumMarkup {x:Type builds:Realm}}}">
                 <metroControls:TextBoxHelper.Watermark>
-                    <l:Catalog Message="Character name"/>
+                    <l:Catalog Message="Realm"/>
                 </metroControls:TextBoxHelper.Watermark>
-            </TextBox>
-            <TextBox Grid.Column="1" Margin="3,5,5,5" Text="{Binding Build.AccountName}" MaxLength="31">
+            </ComboBox>
+            <TextBox Margin="5 0 0 0"
+                     Text="{Binding Build.AccountName}"
+                     MaxLength="31">
                 <metroControls:TextBoxHelper.Watermark>
                     <l:Catalog Message="Account name"/>
                 </metroControls:TextBoxHelper.Watermark>
             </TextBox>
-        </Grid>
+            <ComboBox Margin="5 0 0 0"
+                      Text="{Binding Build.League}"
+                      IsEditable="True"
+                      ItemsSource="{Binding CurrentLeagues.Result}">
+                <metroControls:TextBoxHelper.Watermark>
+                    <l:Catalog Message="League"/>
+                </metroControls:TextBoxHelper.Watermark>
+            </ComboBox>
+            <ComboBox Margin="5 0 0 0"
+                      IsEditable="True"
+                      IsTextSearchEnabled="True" 
+                      IsTextSearchCaseSensitive="False" 
+                      StaysOpenOnEdit="True"
+                      TextSearch.TextPath="Name"
+                      Text="{Binding Build.CharacterName}"
+                      ItemsSource="{Binding AccountCharacters.Result}">
+                <metroControls:TextBoxHelper.Watermark>
+                    <l:Catalog Message="Character name"/>
+                </metroControls:TextBoxHelper.Watermark>
+                <ComboBox.ItemTemplate>
+                    <DataTemplate DataType="viewModels:AccountCharacterViewModel">
+                        <TextBlock>
+                            <Run Text="{Binding Name, Mode=OneWay}" />
+                            (level <Run Text="{Binding Level, Mode=OneWay}" /> <Run Text="{Binding Class, Mode=OneWay}" />
+                            in <Run Text="{Binding League, Mode=OneWay}" />)
+                        </TextBlock>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+        </UniformGrid>
 
-        <Grid Margin="5,5,5,0">
+        <TextBlock Margin="0 3" TextWrapping="Wrap">
+            <l:Catalog Message="Please enter your Character and Account Name below and click 'Open in Browser'."/><LineBreak/>
+            <l:Catalog Message="This will open a page in your default Web-Browser containing your character's item data"/><LineBreak/>
+            <l:Catalog Message="Copy the contents of that page and paste them into the 'Item data' field."/>
+        </TextBlock>
+
+        <Grid Margin="0 3 0 0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
                 <ColumnDefinition Width="Auto" />
@@ -45,13 +105,15 @@
                 <l:Catalog Message="Open in Browser"/>
             </Button>
         </Grid>
-        <TextBox Margin="5" TextWrapping="Wrap" 
+        <TextBox Margin="0 3" TextWrapping="Wrap"
+                 MaxLines="1"
+                 VerticalScrollBarVisibility="Auto"
                  Text="{Binding ItemsLink, Mode=OneWay}" IsReadOnly="True"/>
 
-        <Label HorizontalAlignment="Left" Margin="5,5,0,0">
+        <Label HorizontalAlignment="Left" Margin="0 3 0 0">
             <l:Catalog Message="Item and skill data:"/>
         </Label>
-        <TextBox Margin="5" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"
+        <TextBox Margin="0" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"
                  AcceptsTab="True" AcceptsReturn="True" MaxLines="6"
                  metroControls:TextBoxHelper.ClearTextButton="True"
                  metroControls:TextBoxHelper.SelectAllOnFocus="True"

--- a/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml
+++ b/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml
@@ -66,30 +66,30 @@
                 </Border>
             </Grid>
 
-            <Border Visibility="{Binding ImportItemsTask.IsFaulted, Converter={StaticResource BooleanToVisibilityConverter}}"
+            <Border Visibility="{Binding ImportItemsSkillsAndLevelTask.IsFaulted, Converter={StaticResource BooleanToVisibilityConverter}}"
                     Style="{StaticResource FaultedTaskBorderStyle}">
                 <TextBlock Foreground="{DynamicResource MahApps.Brushes.Text.Validation}">
                     <Run><Run.Text><l:Catalog Message="Importing item and skill data failed:"/></Run.Text></Run>
                     <LineBreak />
-                    <Run Text="{Binding ImportItemsTask.ErrorMessage, Mode=OneWay}" />
+                    <Run Text="{Binding ImportItemsSkillsAndLevelTask.ErrorMessage, Mode=OneWay}" />
                 </TextBlock>
             </Border>
-            <Border Visibility="{Binding ImportItemsTask.IsNotCompleted, Converter={StaticResource BooleanToVisibilityConverter}}"
+            <Border Visibility="{Binding ImportItemsSkillsAndLevelTask.IsNotCompleted, Converter={StaticResource BooleanToVisibilityConverter}}"
                     Style="{StaticResource NotCompletedTaskBorderStyle}">
                 <Label>
                     <l:Catalog Message="Importing item and skill data…"/>
                 </Label>
             </Border>
 
-            <Border Visibility="{Binding ImportPassiveTreeTask.IsFaulted, Converter={StaticResource BooleanToVisibilityConverter}}"
+            <Border Visibility="{Binding ImportPassiveTreeAndJewelsTask.IsFaulted, Converter={StaticResource BooleanToVisibilityConverter}}"
                     Style="{StaticResource FaultedTaskBorderStyle}">
                 <TextBlock Foreground="{DynamicResource MahApps.Brushes.Text.Validation}">
                     <Run><Run.Text><l:Catalog Message="Importing passive tree and jewel data failed:"/></Run.Text></Run>
                     <LineBreak />
-                    <Run Text="{Binding ImportPassiveTreeTask.ErrorMessage, Mode=OneWay}" />
+                    <Run Text="{Binding ImportPassiveTreeAndJewelsTask.ErrorMessage, Mode=OneWay}" />
                 </TextBlock>
             </Border>
-            <Border Visibility="{Binding ImportPassiveTreeTask.IsNotCompleted, Converter={StaticResource BooleanToVisibilityConverter}}"
+            <Border Visibility="{Binding ImportPassiveTreeAndJewelsTask.IsNotCompleted, Converter={StaticResource BooleanToVisibilityConverter}}"
                     Style="{StaticResource NotCompletedTaskBorderStyle}">
                 <Label>
                     <l:Catalog Message="Importing passive tree and jewel data data…"/>

--- a/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml
+++ b/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml
@@ -12,19 +12,55 @@
     xmlns:wpf="clr-namespace:PoESkillTree.Utils.Wpf"
     MinContentWidth="400" MaxContentWidth="800"
     d:DataContext="{d:DesignInstance viewModels:ImportCharacterViewModel}">
+    <dialogs:CloseableBaseDialog.Resources>
+        <Style x:Key="FaultedTaskBorderStyle"
+               TargetType="Border">
+            <Setter Property="Background"
+                    Value="{DynamicResource MahApps.Brushes.Validation5}" />
+            <Setter Property="CornerRadius" Value="2" />
+            <Setter Property="Padding" Value="8 4" />
+            <Setter Property="Margin" Value="0 5 0 0" />
+        </Style>
+        <Style x:Key="NotCompletedTaskBorderStyle"
+               TargetType="Border">
+            <Setter Property="Background"
+                    Value="{DynamicResource MahApps.Brushes.Accent}" />
+            <Setter Property="CornerRadius" Value="2" />
+            <Setter Property="Padding" Value="2 0" />
+            <Setter Property="Margin" Value="0 5 0 0" />
+        </Style>
+    </dialogs:CloseableBaseDialog.Resources>
     <dialogs:CloseableBaseDialog.DialogLeft>
         <StackPanel HorizontalAlignment="Right"
-                    Margin="5 80 5 0"
+                    Margin="10 50 10 0"
                     Visibility="{Binding PublicProfile, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Border Visibility="{Binding CurrentLeagues.IsFaulted, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Style="{StaticResource FaultedTaskBorderStyle}">
+                <TextBlock Foreground="{DynamicResource MahApps.Brushes.Text.Validation}">
+                    <Run><Run.Text><l:Catalog Message="Retrieving leagues for realm failed:"/></Run.Text></Run>
+                    <LineBreak />
+                    <Run Text="{Binding CurrentLeagues.ErrorMessage, Mode=OneWay}" />
+                </TextBlock>
+            </Border>
+            <Border Visibility="{Binding CurrentLeagues.IsNotCompleted, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Style="{StaticResource NotCompletedTaskBorderStyle}">
+                <Label>
+                    <l:Catalog Message="Retrieving leagues for realm…"/>
+                </Label>
+            </Border>
             <Border Visibility="{Binding AccountCharacters.IsFaulted, Converter={StaticResource BooleanToVisibilityConverter}}"
-                    Background="{DynamicResource MahApps.Brushes.Validation5}"
-                    CornerRadius="2">
-                <TextBlock Foreground="{DynamicResource MahApps.Brushes.Text.Validation}"
-                           Margin="4 2">
+                    Style="{StaticResource FaultedTaskBorderStyle}">
+                <TextBlock Foreground="{DynamicResource MahApps.Brushes.Text.Validation}">
                     <Run><Run.Text><l:Catalog Message="Retrieving characters for account failed:"/></Run.Text></Run>
                     <LineBreak />
                     <Run Text="{Binding AccountCharacters.ErrorMessage, Mode=OneWay}" />
                 </TextBlock>
+            </Border>
+            <Border Visibility="{Binding AccountCharacters.IsNotCompleted, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Style="{StaticResource NotCompletedTaskBorderStyle}">
+                <Label>
+                    <l:Catalog Message="Retrieving characters for account…"/>
+                </Label>
             </Border>
         </StackPanel>
     </dialogs:CloseableBaseDialog.DialogLeft>

--- a/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml.cs
+++ b/WPFSKillTree/Views/Import/ImportCharacterWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿namespace PoESkillTree.Views.Equipment
+﻿namespace PoESkillTree.Views.Import
 {
     /// <summary>
     /// Interaction logic for ImportCharacterWindow.xaml

--- a/WPFSKillTree/Views/Import/ImportStashWindow.xaml
+++ b/WPFSKillTree/Views/Import/ImportStashWindow.xaml
@@ -8,6 +8,9 @@
     xmlns:metroControls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
     xmlns:dialogs="clr-namespace:PoESkillTree.Controls.Dialogs"
     xmlns:viewModels="clr-namespace:PoESkillTree.ViewModels.Import"
+    xmlns:wpf="clr-namespace:PoESkillTree.Utils.Wpf"
+    xmlns:builds="clr-namespace:PoESkillTree.Model.Builds"
+    MinContentWidth="800"
     d:DataContext="{d:DesignInstance viewModels:ImportStashViewModel}">
     <Grid>
         <Grid.ColumnDefinitions>
@@ -24,28 +27,35 @@
 
         <TextBlock Margin="5" TextWrapping="Wrap"
                    Grid.Column="0" Grid.Row="0">
-            <l:Catalog Message="Please enter your Account Name and league below and click on 'Open in Browser'."/><LineBreak/>
+            <l:Catalog Message="Enter your realm, account name and league below and click 'Open in Browser'."/><LineBreak/>
             <l:Catalog Message="This will open a page in your default Web-browser containing a list of your stash tabs."/><LineBreak/>
-            <l:Catalog Message="Copy the contents of that page and click 'Load stash tab list'."/>
+            <l:Catalog Message="Copy the contents of that page and click 'Load stash tab list from clipboard'."/>
         </TextBlock>
 
-        <Grid Grid.Column="0" Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
-            <ComboBox Margin="5,5,2,5" Text="{Binding Build.League}" IsEditable="True"
+        <UniformGrid Grid.Column="0" Grid.Row="1"
+                     Margin="5"
+                     Columns="3">
+            <ComboBox Margin="0"
+                      Text="{Binding Build.Realm}"
+                      ItemsSource="{Binding Source={wpf:EnumMarkup {x:Type builds:Realm}}}">
+                <metroControls:TextBoxHelper.Watermark>
+                    <l:Catalog Message="Realm"/>
+                </metroControls:TextBoxHelper.Watermark>
+            </ComboBox>
+            <ComboBox Margin="5 0 0 0"
+                      Text="{Binding Build.League}" IsEditable="True"
                       ItemsSource="{Binding CurrentLeagues.Result}">
                 <metroControls:TextBoxHelper.Watermark>
                     <l:Catalog Message="League"/>
                 </metroControls:TextBoxHelper.Watermark>
             </ComboBox>
-            <TextBox Grid.Column="1" Margin="3,5,5,5" Text="{Binding Build.AccountName}" MaxLength="31">
+            <TextBox Margin="5 0 0 0"
+                     Text="{Binding Build.AccountName}" MaxLength="31">
                 <metroControls:TextBoxHelper.Watermark>
                     <l:Catalog Message="Account name"/>
                 </metroControls:TextBoxHelper.Watermark>
             </TextBox>
-        </Grid>
+        </UniformGrid>
 
         <Grid Margin="5,5,5,0"
               Grid.Column="0" Grid.Row="2">
@@ -64,7 +74,9 @@
         </Grid>
         <TextBox Margin="5" TextWrapping="Wrap" 
                  Text="{Binding TabsLink, Mode=OneWay}" IsReadOnly="True"
-                 Grid.Column="0" Grid.Row="3" MinLines="4"
+                 Grid.Column="0" Grid.Row="3"
+                 MinLines="3" MaxLines="3"
+                 VerticalScrollBarVisibility="Auto"
                  metroControls:TextBoxHelper.SelectAllOnFocus="True" />
         <Button Command="{Binding LoadTabsCommand}"
                 HorizontalAlignment="Right" Margin="5,0,5,5"
@@ -74,9 +86,9 @@
 
         <TextBlock Margin="5" TextWrapping="Wrap"
                    Grid.Column="1" Grid.Row="0">
-            <l:Catalog Message="Select a stash tab and click 'Open in browser' below"/><LineBreak/>
+            <l:Catalog Message="Select a stash tab and click 'Open in browser' below."/><LineBreak/>
             <l:Catalog Message="This will open a page in your default Web-browser containing the item data of the selected stash."/><LineBreak/>
-            <l:Catalog Message="Copy the contents of that page and click 'Load stash tab'."/>
+            <l:Catalog Message="Copy the contents of that page and click 'Load stash tab from clipboard'."/>
         </TextBlock>
 
         <ComboBox Margin="5" ItemsSource="{Binding TabsView}" DisplayMemberPath="Name"
@@ -113,7 +125,9 @@
         </Grid>
         <TextBox Margin="5" TextWrapping="Wrap" 
                  Text="{Binding TabLink, Mode=OneWay}" IsReadOnly="True"
-                 Grid.Column="1" Grid.Row="3" MinLines="4"
+                 Grid.Column="1" Grid.Row="3"
+                 MinLines="3" MaxLines="3"
+                 VerticalScrollBarVisibility="Auto"
                  metroControls:TextBoxHelper.SelectAllOnFocus="True" />
         <Button Command="{Binding LoadTabContentsCommand}"
                 HorizontalAlignment="Right" Margin="5,0,5,5"

--- a/WPFSKillTree/Views/Import/ImportStashWindow.xaml
+++ b/WPFSKillTree/Views/Import/ImportStashWindow.xaml
@@ -42,6 +42,12 @@
                     <l:Catalog Message="Realm"/>
                 </metroControls:TextBoxHelper.Watermark>
             </ComboBox>
+            <TextBox Margin="5 0 0 0"
+                     Text="{Binding Build.AccountName}" MaxLength="31">
+                <metroControls:TextBoxHelper.Watermark>
+                    <l:Catalog Message="Account name"/>
+                </metroControls:TextBoxHelper.Watermark>
+            </TextBox>
             <ComboBox Margin="5 0 0 0"
                       Text="{Binding Build.League}" IsEditable="True"
                       ItemsSource="{Binding CurrentLeagues.Result}">
@@ -49,12 +55,6 @@
                     <l:Catalog Message="League"/>
                 </metroControls:TextBoxHelper.Watermark>
             </ComboBox>
-            <TextBox Margin="5 0 0 0"
-                     Text="{Binding Build.AccountName}" MaxLength="31">
-                <metroControls:TextBoxHelper.Watermark>
-                    <l:Catalog Message="Account name"/>
-                </metroControls:TextBoxHelper.Watermark>
-            </TextBox>
         </UniformGrid>
 
         <Grid Margin="5,5,5,0"
@@ -75,7 +75,7 @@
         <TextBox Margin="5" TextWrapping="Wrap" 
                  Text="{Binding TabsLink, Mode=OneWay}" IsReadOnly="True"
                  Grid.Column="0" Grid.Row="3"
-                 MinLines="3" MaxLines="3"
+                 MinLines="2" MaxLines="2"
                  VerticalScrollBarVisibility="Auto"
                  metroControls:TextBoxHelper.SelectAllOnFocus="True" />
         <Button Command="{Binding LoadTabsCommand}"
@@ -126,7 +126,7 @@
         <TextBox Margin="5" TextWrapping="Wrap" 
                  Text="{Binding TabLink, Mode=OneWay}" IsReadOnly="True"
                  Grid.Column="1" Grid.Row="3"
-                 MinLines="3" MaxLines="3"
+                 MinLines="2" MaxLines="2"
                  VerticalScrollBarVisibility="Auto"
                  metroControls:TextBoxHelper.SelectAllOnFocus="True" />
         <Button Command="{Binding LoadTabContentsCommand}"

--- a/WPFSKillTree/Views/Import/ImportStashWindow.xaml
+++ b/WPFSKillTree/Views/Import/ImportStashWindow.xaml
@@ -1,5 +1,5 @@
 ﻿<dialogs:CloseableBaseDialog
-    x:Class="PoESkillTree.Views.Equipment.ImportStashWindow"
+    x:Class="PoESkillTree.Views.Import.ImportStashWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:l="clr-namespace:PoESkillTree.Localization.XAML"
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d"
     xmlns:metroControls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
     xmlns:dialogs="clr-namespace:PoESkillTree.Controls.Dialogs"
-    xmlns:viewModels="clr-namespace:PoESkillTree.ViewModels.Equipment"
+    xmlns:viewModels="clr-namespace:PoESkillTree.ViewModels.Import"
     d:DataContext="{d:DesignInstance viewModels:ImportStashViewModel}">
     <Grid>
         <Grid.ColumnDefinitions>

--- a/WPFSKillTree/Views/Import/ImportStashWindow.xaml.cs
+++ b/WPFSKillTree/Views/Import/ImportStashWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿namespace PoESkillTree.Views.Equipment
+﻿namespace PoESkillTree.Views.Import
 {
     /// <summary>
     /// Interaction logic for ImportStashWindow.xaml

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -634,8 +634,8 @@
                     </Popup>
                     <controls:NumericUpDown Margin="5,0,0,0" x:Name="LevelUpDown" ValueChanged="Level_ValueChanged" MinWidth="70"
                                             Height="{Binding ActualHeight, ElementName=cbCharType}"
-                                            DataContext="{Binding Tree, ElementName=window}" Value="{Binding Level, ValidatesOnDataErrors=True}"
-                                            Minimum="{Binding UndefinedLevel}" Maximum="{Binding MaximumLevel}"
+                                            Value="{Binding PersistentData.CurrentBuild.Level, ValidatesOnDataErrors=True}"
+                                            Minimum="0" Maximum="100"
                                             NumericInputMode="Numbers">
                         <controls:NumericUpDown.ToolTip>
                             <l:Catalog Message="Level"/>

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -456,9 +456,9 @@
                     </MenuItem.Icon>
                 </MenuItem>
                 <Separator />
-                <MenuItem Click="Menu_ImportItems">
+                <MenuItem Click="Menu_ImportCharacter">
                     <MenuItem.Header>
-                        <l:Catalog Message="_Download &amp; Import Items…"/>
+                        <l:Catalog Message="Import _Character…"/>
                     </MenuItem.Header>
                     <MenuItem.Icon>
                         <iconPacks:PackIconModern Kind="CloudDownload" HorizontalAlignment="Center" />
@@ -466,7 +466,7 @@
                 </MenuItem>
                 <MenuItem Click="Menu_ImportStash">
                     <MenuItem.Header>
-                        <l:Catalog Message="_Download &amp; Import Stash…"/>
+                        <l:Catalog Message="Import _Stash…"/>
                     </MenuItem.Header>
                     <MenuItem.Icon>
                         <iconPacks:PackIconModern Kind="CloudDownload" HorizontalAlignment="Center" />
@@ -709,8 +709,8 @@
                                                  Height="32"
                                                  Rows="1">
                                         <Button Margin="0 0 4 0"
-                                                Click="Menu_ImportItems">
-                                            <l:Catalog>Import Items</l:Catalog>
+                                                Click="Menu_ImportCharacter">
+                                            <l:Catalog>Import Character</l:Catalog>
                                         </Button>
                                         <Button Margin="4 0"
                                                 Click="Menu_ImportStash">

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -120,7 +120,7 @@ namespace PoESkillTree.Views
             get => _computationViewModel;
             private set
             {
-                value!.SharedConfiguration.SetLevel(Tree.Level);
+                value!.SharedConfiguration.SetLevel(PersistentData.CurrentBuild.Level);
                 value.SharedConfiguration.SetCharacterClass(Tree.CharClass);
                 value.SharedConfiguration.SetBandit(PersistentData.CurrentBuild.Bandits.Choice);
                 SetProperty(ref _computationViewModel, value);
@@ -308,6 +308,9 @@ namespace PoESkillTree.Views
                 case nameof(BanditSettings.Choice):
                     UpdateUI();
                     ComputationViewModel?.SharedConfiguration.SetBandit(PersistentData.CurrentBuild.Bandits.Choice);
+                    break;
+                case nameof(PoEBuild.Level):
+                    ComputationViewModel?.SharedConfiguration.SetLevel(PersistentData.CurrentBuild.Level);
                     break;
             }
         }
@@ -646,10 +649,6 @@ namespace PoESkillTree.Views
         {
             switch (e.PropertyName)
             {
-                case nameof(SkillTree.Level):
-                    PersistentData.CurrentBuild.Level = Tree.Level;
-                    ComputationViewModel?.SharedConfiguration.SetLevel(Tree.Level);
-                    break;
                 case nameof(SkillTree.CharClass):
                     Tree.UpdateAscendancyClasses = true;
                     PopulateAscendancySelectionList();
@@ -1191,6 +1190,8 @@ namespace PoESkillTree.Views
 
         private void Level_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double?> args)
         {
+            if (Tree == null)
+                return;
             UpdateUI();
         }
 
@@ -1721,7 +1722,6 @@ namespace PoESkillTree.Views
         {
             var build = PersistentData.CurrentBuild;
             InputTreeUrl = PersistentData.CurrentBuild.TreeUrl;
-            Tree.Level = build.Level;
             Tree.ResetTaggedNodes();
             TreeGeneratorInteraction?.LoadSettings();
             await LoadItemData();

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -933,7 +933,7 @@ namespace PoESkillTree.Views
 
         private async void Menu_ImportCharacter(object sender, RoutedEventArgs e)
         {
-            await this.ShowDialogAsync(_importViewModels.ImportCharacter, new ImportCharacterWindow());
+            await this.ShowDialogAsync(_importViewModels.ImportCharacter(ItemAttributes), new ImportCharacterWindow());
         }
 
         private async void Menu_ImportStash(object sender, RoutedEventArgs e)

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -107,6 +107,8 @@ namespace PoESkillTree.Views
 
         public StashViewModel StashViewModel { get; } = new StashViewModel();
 
+        private ImportViewModels _importViewModels;
+
         private readonly ObservableItemCollectionConverter
             _equipmentConverter = new ObservableItemCollectionConverter();
 
@@ -552,6 +554,7 @@ namespace PoESkillTree.Views
             _dialogCoordinator = new ExtendedDialogCoordinator(_gameData, PersistentData);
             RegisterPersistentDataHandlers();
             StashViewModel.Initialize(_dialogCoordinator, PersistentData);
+            _importViewModels = new ImportViewModels(_dialogCoordinator, PersistentData, StashViewModel);
             // Set theme & accent.
             SetTheme(PersistentData.Options.Theme);
             SetAccent(PersistentData.Options.Accent);
@@ -930,15 +933,12 @@ namespace PoESkillTree.Views
 
         private async void Menu_ImportCharacter(object sender, RoutedEventArgs e)
         {
-            await this.ShowDialogAsync(
-                new ImportCharacterViewModel(PersistentData.CurrentBuild),
-                new ImportCharacterWindow());
+            await this.ShowDialogAsync(_importViewModels.ImportCharacter, new ImportCharacterWindow());
         }
 
         private async void Menu_ImportStash(object sender, RoutedEventArgs e)
         {
-            var vm = new ImportStashViewModel(DialogCoordinator.Instance, PersistentData, StashViewModel);
-            await this.ShowDialogAsync(vm, new ImportStashWindow(), () => vm.ViewLoaded());
+            await this.ShowDialogAsync(_importViewModels.ImportStash, new ImportStashWindow());
         }
 
         private async void Menu_CopyStats(object sender, RoutedEventArgs e)
@@ -1008,12 +1008,12 @@ namespace PoESkillTree.Views
 
         private void Menu_OpenPoEWebsite(object sender, RoutedEventArgs e)
         {
-            Process.Start("https://www.pathofexile.com/");
+            Util.OpenInBrowser("https://www.pathofexile.com/");
         }
 
         private void Menu_OpenWiki(object sender, RoutedEventArgs e)
         {
-            Process.Start("http://pathofexile.gamepedia.com/");
+            Util.OpenInBrowser("http://pathofexile.gamepedia.com/");
         }
 
         private async void Menu_OpenHelp(object sender, RoutedEventArgs e)

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -43,8 +43,9 @@ using PoESkillTree.ViewModels;
 using PoESkillTree.ViewModels.Builds;
 using PoESkillTree.ViewModels.Crafting;
 using PoESkillTree.ViewModels.Equipment;
+using PoESkillTree.ViewModels.Import;
 using PoESkillTree.Views.Crafting;
-using PoESkillTree.Views.Equipment;
+using PoESkillTree.Views.Import;
 using Attribute = PoESkillTree.ViewModels.Attribute;
 using Item = PoESkillTree.Model.Items.Item;
 

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -932,7 +932,9 @@ namespace PoESkillTree.Views
 
         private async void Menu_ImportCharacter(object sender, RoutedEventArgs e)
         {
-            await this.ShowDialogAsync(_importViewModels.ImportCharacter(ItemAttributes), new ImportCharacterWindow());
+            await this.ShowDialogAsync(_importViewModels.ImportCharacter(ItemAttributes, Tree), new ImportCharacterWindow());
+            UpdateUI();
+            SetCurrentBuildUrlFromTree();
         }
 
         private async void Menu_ImportStash(object sender, RoutedEventArgs e)

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -927,17 +927,17 @@ namespace PoESkillTree.Views
             }
         }
 
-        private async void Menu_ImportItems(object sender, RoutedEventArgs e)
+        private async void Menu_ImportCharacter(object sender, RoutedEventArgs e)
         {
             await this.ShowDialogAsync(
-                new DownloadItemsViewModel(PersistentData.CurrentBuild),
-                new DownloadItemsWindow());
+                new ImportCharacterViewModel(PersistentData.CurrentBuild),
+                new ImportCharacterWindow());
         }
 
         private async void Menu_ImportStash(object sender, RoutedEventArgs e)
         {
-            var vm = new DownloadStashViewModel(DialogCoordinator.Instance, PersistentData, StashViewModel);
-            await this.ShowDialogAsync(vm, new DownloadStashWindow(), () => vm.ViewLoaded());
+            var vm = new ImportStashViewModel(DialogCoordinator.Instance, PersistentData, StashViewModel);
+            await this.ShowDialogAsync(vm, new ImportStashWindow(), () => vm.ViewLoaded());
         }
 
         private async void Menu_CopyStats(object sender, RoutedEventArgs e)


### PR DESCRIPTION
The import character window can now import items, skills, level, passive tree and jewels. Each together and separately.

If an account name is entered, that account's characters are retrieved. The character list can be filtered by league. The character and stash importers supports the different realms.

For public profiles, importing is done with a button press. For private profiles, the button press opens another dialog and the API page in a web browser. The results then have to be pasted into the dialog.

Progress and errors are displayed to the left of the dialog content.

Close #543

![image](https://user-images.githubusercontent.com/7596346/71326642-e37a7280-24fd-11ea-84c7-62e52d0d6ddf.png)
