### PR TITLE
Improved skills support, secondary skills and socketed gem modifiers

### DIFF
--- a/UpdateDB/UpdateDB.csproj
+++ b/UpdateDB/UpdateDB.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NLog" Version="4.6.8" />
-    <PackageReference Include="PoESkillTree.Engine" Version="0.2.0" />
+    <PackageReference Include="PoESkillTree.Engine" Version="0.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\WPFSKillTree\WPFSKillTree.csproj" />

--- a/UpdateDB/UpdateDB.csproj
+++ b/UpdateDB/UpdateDB.csproj
@@ -7,10 +7,10 @@
     <WarningsAsErrors>8600;8601;8602;8603;8604;8613;8619;8620;8625</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="morelinq" Version="3.3.1" />
+    <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NLog" Version="4.6.8" />
-    <PackageReference Include="PoESkillTree.Engine" Version="0.1.10" />
+    <PackageReference Include="PoESkillTree.Engine" Version="0.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\WPFSKillTree\WPFSKillTree.csproj" />

--- a/WPFSKillTree.Tests/Computation/Model/ComputationObservablesTest.cs
+++ b/WPFSKillTree.Tests/Computation/Model/ComputationObservablesTest.cs
@@ -56,7 +56,7 @@ namespace PoESkillTree.Computation.Model
             var parseResults = CreateParseResults(expected);
             var sut = CreateSut(MockSkilledPassiveNodeParser(parseResults));
 
-            var actual = await AggregateAsync(sut.ParseSkilledPassiveNodes(skilledNodes));
+            var actual = await sut.ParseSkilledPassiveNodesAsync(skilledNodes);
 
             Assert.AreEqual(expected, actual.AddedModifiers);
             Assert.IsEmpty(actual.RemovedModifiers);
@@ -98,7 +98,7 @@ namespace PoESkillTree.Computation.Model
             var parser = MockItemParser(items, parseResults);
             var sut = CreateSut(parser);
 
-            var actual = await AggregateAsync(sut.ParseItems(items));
+            var actual = await sut.ParseItemsAsync(items);
 
             Assert.AreEqual(expected, actual.AddedModifiers);
             Assert.IsEmpty(actual.RemovedModifiers);
@@ -140,7 +140,7 @@ namespace PoESkillTree.Computation.Model
             var parser = MockSkillParser(skills, parseResults);
             var sut = CreateSut(parser);
 
-            var actual = await AggregateAsync(sut.ParseSkills(skills));
+            var actual = await sut.ParseSkillsAsync(skills);
 
             Assert.AreEqual(expected, actual.AddedModifiers);
             Assert.IsEmpty(actual.RemovedModifiers);

--- a/WPFSKillTree.Tests/Computation/Model/ComputationObservablesTest.cs
+++ b/WPFSKillTree.Tests/Computation/Model/ComputationObservablesTest.cs
@@ -42,7 +42,7 @@ namespace PoESkillTree.Computation.Model
             var sut = CreateSut(parser);
 
             var actual =
-                await AggregateAsync(sut.InitialParse(passiveTree, TimeSpan.Zero, ImmediateScheduler.Instance));
+                await AggregateAsync(sut.InitialParse(passiveTree, TimeSpan.Zero));
 
             Assert.That(actual.AddedModifiers, Is.EquivalentTo(expected));
             Assert.IsEmpty(actual.RemovedModifiers);
@@ -251,7 +251,7 @@ namespace PoESkillTree.Computation.Model
             };
 
         private static ComputationObservables CreateSut(IParser parser)
-            => new ComputationObservables(parser);
+            => new ComputationObservables(parser, ImmediateScheduler.Instance);
 
         private static async Task<CalculatorUpdate> AggregateAsync(IObservable<CalculatorUpdate> observable)
             => await observable

--- a/WPFSKillTree.Tests/Computation/Model/ComputationObservablesTest.cs
+++ b/WPFSKillTree.Tests/Computation/Model/ComputationObservablesTest.cs
@@ -11,6 +11,7 @@ using PoESkillTree.Engine.Computation.Builders.Stats;
 using PoESkillTree.Engine.Computation.Common;
 using PoESkillTree.Engine.Computation.Core;
 using PoESkillTree.Engine.Computation.Parsing;
+using PoESkillTree.Engine.GameModel;
 using PoESkillTree.Engine.GameModel.Items;
 using PoESkillTree.Engine.GameModel.PassiveTree;
 using PoESkillTree.Engine.GameModel.Skills;
@@ -192,7 +193,7 @@ namespace PoESkillTree.Computation.Model
                 if (i < items.Count)
                 {
                     var item = items[i].Item1;
-                    parser.Setup(p => p.ParseItem(item, slot)).Returns(parseResults[i]);
+                    parser.Setup(p => p.ParseItem(item, slot, Entity.Character)).Returns(parseResults[i]);
                 }
             }
             return parser.Object;
@@ -205,7 +206,7 @@ namespace PoESkillTree.Computation.Model
             for (var i = 0; i < skills.Count; i++)
             {
                 var id = i;
-                parser.Setup(p => p.ParseSkills(skills[id])).Returns(parseResults[i]);
+                parser.Setup(p => p.ParseSkills(skills[id], Entity.Character)).Returns(parseResults[i]);
             }
             return parser.Object;
         }
@@ -232,8 +233,8 @@ namespace PoESkillTree.Computation.Model
         private static IReadOnlyList<IReadOnlyList<Skill>> CreateSkills()
             => Enumerable.Range(0, 3).Select(i => Enumerable.Range(i, 2).Select(CreateSkill).ToList()).ToList();
 
-        private static Skill CreateSkill(int id)
-            => new Skill(id.ToString(), 1, 0, default, 0, 0);
+        private static Skill CreateSkill(int id) =>
+            Skill.FromGem(new Gem(id.ToString(), 1, 0, default, 0, 0, true), true);
 
         private static List<Modifier> CreateModifiers(int count)
             => Enumerable.Range(0, count).Select(i => CreateModifier(i.ToString())).ToList();

--- a/WPFSKillTree.Tests/Computation/Model/ComputationObservablesTest.cs
+++ b/WPFSKillTree.Tests/Computation/Model/ComputationObservablesTest.cs
@@ -251,7 +251,7 @@ namespace PoESkillTree.Computation.Model
             };
 
         private static ComputationObservables CreateSut(IParser parser)
-            => new ComputationObservables(parser, ImmediateScheduler.Instance);
+            => new ComputationObservables(parser, ImmediateScheduler.Instance, ImmediateScheduler.Instance);
 
         private static async Task<CalculatorUpdate> AggregateAsync(IObservable<CalculatorUpdate> observable)
             => await observable

--- a/WPFSKillTree.Tests/WPFSKillTree.Tests.csproj
+++ b/WPFSKillTree.Tests/WPFSKillTree.Tests.csproj
@@ -11,14 +11,17 @@
     <WarningsAsErrors>8600;8601;8602;8603;8604;8613;8619;8620;8625</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Enums.NET" Version="3.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Enums.NET" Version="3.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="morelinq" Version="3.3.1" />
+    <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="PoESkillTree.Engine" Version="0.1.10" />
-    <PackageReference Include="System.Reactive" Version="4.3.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="PoESkillTree.Engine" Version="0.2.0" />
+    <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\WPFSKillTree\WPFSKillTree.csproj" />

--- a/WPFSKillTree.Tests/WPFSKillTree.Tests.csproj
+++ b/WPFSKillTree.Tests/WPFSKillTree.Tests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="PoESkillTree.Engine" Version="0.2.0" />
+    <PackageReference Include="PoESkillTree.Engine" Version="0.2.1" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup>

--- a/WPFSKillTree/Computation/ComputationInitializer.cs
+++ b/WPFSKillTree/Computation/ComputationInitializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -68,7 +68,7 @@ namespace PoESkillTree.Computation
             _parser = await computationFactory.CreateParserAsync();
 
             _schedulers = new ComputationSchedulerProvider();
-            _observables = new ComputationObservables(_parser, _schedulers.CalculationThread);
+            _observables = new ComputationObservables(_parser, _schedulers.TaskPool, _schedulers.CalculationThread);
             _calculator = new ObservableCalculator(_iCalculator, _schedulers.CalculationThread);
         }
 

--- a/WPFSKillTree/Computation/ComputationInitializer.cs
+++ b/WPFSKillTree/Computation/ComputationInitializer.cs
@@ -135,6 +135,9 @@ namespace PoESkillTree.Computation
             _calculator.SubscribeTo(changeObservable);
         }
 
+        public AdditionalSkillStatApplier CreateAdditionalSkillStatApplier() =>
+            new AdditionalSkillStatApplier(_calculator, _builderFactories.StatBuilders.Gem);
+
         public async Task<ComputationViewModel> CreateComputationViewModelAsync(IPersistentData persistentData)
         {
             var vm =

--- a/WPFSKillTree/Computation/ComputationInitializer.cs
+++ b/WPFSKillTree/Computation/ComputationInitializer.cs
@@ -94,28 +94,28 @@ namespace PoESkillTree.Computation
 
         private async Task ConnectToSkilledPassiveNodesAsync(ObservableSet<SkillNode> skilledNodes)
             => await ConnectAsync(
-                _observables.ParseSkilledPassiveNodes(skilledNodes),
+                _observables.ParseSkilledPassiveNodesAsync(skilledNodes),
                 _observables.ObserveSkilledPassiveNodes(skilledNodes));
 
         private async Task ConnectToEquipmentAsync(ObservableSet<(Item, ItemSlot)> items)
             => await ConnectAsync(
-                _observables.ParseItems(items),
+                _observables.ParseItemsAsync(items),
                 _observables.ObserveItems(items));
 
         private async Task ConnectToJewelsAsync(ObservableSet<(Item, ItemSlot, ushort, JewelRadius)> jewels)
             => await ConnectAsync(
-                _observables.ParseJewels(jewels),
+                _observables.ParseJewelsAsync(jewels),
                 _observables.ObserveJewels(jewels));
 
         private async Task ConnectToSkillsAsync(ObservableSet<IReadOnlyList<Skill>> skills)
             => await ConnectAsync(
-                _observables.ParseSkills(skills),
+                _observables.ParseSkillsAsync(skills),
                 _observables.ObserveSkills(skills));
 
         private async Task ConnectAsync(
-            IObservable<CalculatorUpdate> initialObservable, IObservable<CalculatorUpdate> changeObservable)
+            Task<CalculatorUpdate> initialUpdate, IObservable<CalculatorUpdate> changeObservable)
         {
-            await _calculator.ForEachUpdateCalculatorAsync(initialObservable);
+            await _calculator.UpdateCalculatorAsync(initialUpdate);
             _calculator.SubscribeTo(changeObservable);
         }
 

--- a/WPFSKillTree/Computation/Model/AdditionalSkillStatApplier.cs
+++ b/WPFSKillTree/Computation/Model/AdditionalSkillStatApplier.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using NLog;
+using PoESkillTree.Engine.Computation.Common;
+using PoESkillTree.Engine.Computation.Common.Builders.Stats;
+using PoESkillTree.Engine.GameModel;
+using PoESkillTree.Engine.GameModel.Items;
+using PoESkillTree.Engine.GameModel.Skills;
+using PoESkillTree.Engine.Utils;
+using PoESkillTree.Engine.Utils.Extensions;
+
+namespace PoESkillTree.Computation.Model
+{
+    public class AdditionalSkillStatApplier
+    {
+        private static readonly ILogger Log = LogManager.GetCurrentClassLogger();
+
+        private readonly ObservableCalculator _calculator;
+        private readonly IGemStatBuilders _gemStatBuilders;
+
+        private readonly Dictionary<DictKey, int> _levels = new Dictionary<DictKey, int>();
+        private readonly Dictionary<DictKey, IDisposable> _levelSubscriptions = new Dictionary<DictKey, IDisposable>();
+
+        private readonly Dictionary<DictKey, int> _qualities = new Dictionary<DictKey, int>();
+        private readonly Dictionary<DictKey, IDisposable> _qualitySubscriptions = new Dictionary<DictKey, IDisposable>();
+
+        public AdditionalSkillStatApplier(ObservableCalculator calculator, IGemStatBuilders gemStatBuilders)
+        {
+            _calculator = calculator;
+            _gemStatBuilders = gemStatBuilders;
+        }
+
+        public Skill Apply(Skill skill)
+        {
+            if (skill.Gem is null)
+                return skill;
+
+            var key = new DictKey(skill);
+            EnsureIsObserved(skill, key);
+
+            if (_levels.TryGetValue(key, out var additionalLevels))
+            {
+                skill = skill.WithLevel(skill.Gem.Level + additionalLevels);
+            }
+
+            if (_qualities.TryGetValue(key, out var additionalQuality))
+            {
+                skill = skill.WithQuality(skill.Gem!.Quality + additionalQuality);
+            }
+
+            return skill;
+        }
+
+        private void EnsureIsObserved(Skill skill, DictKey key)
+        {
+            if (!_levelSubscriptions.ContainsKey(key))
+            {
+                ObserveLevel(skill, key);
+            }
+
+            if (!_qualitySubscriptions.ContainsKey(key))
+            {
+                ObserveQuality(skill, key);
+            }
+        }
+
+        private void ObserveLevel(Skill skill, DictKey key)
+        {
+            var levelStat = _gemStatBuilders.AdditionalLevels(skill).BuildToStats(Entity.Character).Single();
+            _levelSubscriptions[key] = _calculator.ObserveNode(levelStat)
+                .ObserveOnDispatcher()
+                .Subscribe(v =>
+                {
+                    var level = (int) (v.SingleOrNull() ?? 0);
+                    if (_levels.TryGetValue(key, out var oldLevel) && oldLevel == level)
+                        return;
+                    _levels[key] = level;
+                    StatChangedForSlot?.Invoke(this, skill.ItemSlot);
+                }, e => Log.Error(e, $"ObserveLevel({skill}, {key}) failed"));
+        }
+
+        private void ObserveQuality(Skill skill, DictKey key)
+        {
+            var qualityStat = _gemStatBuilders.AdditionalQuality(skill).BuildToStats(Entity.Character).Single();
+            _qualitySubscriptions[key] = _calculator.ObserveNode(qualityStat)
+                .ObserveOnDispatcher()
+                .Subscribe(v =>
+                {
+                    var quality = (int) (v.SingleOrNull() ?? 0);
+                    if (_qualities.TryGetValue(key, out var oldLevel) && oldLevel == quality)
+                        return;
+                    _qualities[key] = quality;
+                    StatChangedForSlot?.Invoke(this, skill.ItemSlot);
+                }, e => Log.Error(e, $"ObserveQuality({skill}, {key}) failed"));
+        }
+
+        public event EventHandler<ItemSlot>? StatChangedForSlot;
+
+        public void CleanSubscriptions(IReadOnlyCollection<IReadOnlyList<Skill>> removedItems, IReadOnlyCollection<IReadOnlyList<Skill>> addedItems)
+        {
+            var removedItemKeys = removedItems.Flatten().Select(s => new DictKey(s));
+            var addedItemKeys = addedItems.Flatten().Select(s => new DictKey(s));
+            var removableKeys = removedItemKeys.Except(addedItemKeys).ToHashSet();
+            foreach (var key in removableKeys)
+            {
+                if (_levelSubscriptions.TryGetValue(key, out var levelSubscription))
+                {
+                    levelSubscription.Dispose();
+                }
+
+                if (_qualitySubscriptions.TryGetValue(key, out var qualitySubscription))
+                {
+                    qualitySubscription.Dispose();
+                }
+
+                _levels.Remove(key);
+                _levelSubscriptions.Remove(key);
+                _qualities.Remove(key);
+                _qualitySubscriptions.Remove(key);
+            }
+        }
+
+        private class DictKey : ValueObject
+        {
+            private readonly object _tuple;
+
+            public DictKey(Skill skill)
+            {
+                _tuple = (skill.ItemSlot, skill.SocketIndex, skill.SkillIndex);
+            }
+
+            protected override object ToTuple() => _tuple;
+        }
+    }
+}

--- a/WPFSKillTree/Computation/Model/ComputationFactory.cs
+++ b/WPFSKillTree/Computation/Model/ComputationFactory.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using PoESkillTree.Engine.Computation.Builders;
 using PoESkillTree.Engine.Computation.Common.Builders;
 using PoESkillTree.Engine.Computation.Core;
+using PoESkillTree.Engine.Computation.Core.Nodes;
 using PoESkillTree.Engine.Computation.Data;
 using PoESkillTree.Engine.Computation.Data.Steps;
 using PoESkillTree.Engine.Computation.Parsing;
@@ -12,20 +13,23 @@ namespace PoESkillTree.Computation.Model
 {
     public class ComputationFactory
     {
+        private readonly Lazy<ICalculator> _calculator;
         private readonly Lazy<Task<IBuilderFactories>> _builderFactories;
         private readonly Lazy<Task<IParser>> _parser;
 
         public ComputationFactory(GameData gameData)
         {
+            _calculator = new Lazy<ICalculator>(Calculator.Create);
             _builderFactories = new Lazy<Task<IBuilderFactories>>(
                 () => BuilderFactories.CreateAsync(gameData));
             _parser = new Lazy<Task<IParser>>(
-                () => Parser<ParsingStep>.CreateAsync(gameData, _builderFactories.Value,
-                    ParsingData.CreateAsync(gameData, _builderFactories.Value)));
+                async () => await Parser<ParsingStep>.CreateAsync(gameData, _builderFactories.Value,
+                    ParsingData.CreateAsync(gameData, _builderFactories.Value),
+                    new SimpleValueCalculationContext(_calculator.Value.NodeRepository)));
         }
 
         public ICalculator CreateCalculator()
-            => Calculator.Create();
+            => _calculator.Value;
 
         public Task<IBuilderFactories> CreateBuilderFactoriesAsync()
             => _builderFactories.Value;

--- a/WPFSKillTree/Computation/Model/ComputationFactory.cs
+++ b/WPFSKillTree/Computation/Model/ComputationFactory.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using PoESkillTree.Engine.Computation.Builders;
 using PoESkillTree.Engine.Computation.Common.Builders;
 using PoESkillTree.Engine.Computation.Core;
-using PoESkillTree.Engine.Computation.Core.Nodes;
 using PoESkillTree.Engine.Computation.Data;
 using PoESkillTree.Engine.Computation.Data.Steps;
 using PoESkillTree.Engine.Computation.Parsing;
@@ -24,8 +23,7 @@ namespace PoESkillTree.Computation.Model
                 () => BuilderFactories.CreateAsync(gameData));
             _parser = new Lazy<Task<IParser>>(
                 async () => await Parser<ParsingStep>.CreateAsync(gameData, _builderFactories.Value,
-                    ParsingData.CreateAsync(gameData, _builderFactories.Value),
-                    new SimpleValueCalculationContext(_calculator.Value.NodeRepository)));
+                    ParsingData.CreateAsync(gameData, _builderFactories.Value)));
         }
 
         public ICalculator CreateCalculator()

--- a/WPFSKillTree/Computation/Model/ComputationObservables.cs
+++ b/WPFSKillTree/Computation/Model/ComputationObservables.cs
@@ -119,17 +119,10 @@ namespace PoESkillTree.Computation.Model
             return (calculatorUpdate, skills);
         }
 
-        private (IReadOnlyList<Modifier> modifiers, IReadOnlyList<Skill> skills) ParseGems(IEnumerable<Gem> gems)
+        private (IReadOnlyList<Modifier> modifiers, IReadOnlyList<Skill> skills) ParseGems(IReadOnlyList<Gem> gems)
         {
-            var skills = new List<Skill>();
-            var modifiers = new List<Modifier>();
-            foreach (var gem in gems)
-            {
-                modifiers.AddRange(_parser.ParseGem(gem, out var newSkills).Modifiers);
-                skills.AddRange(newSkills);
-            }
-
-            return (modifiers, skills);
+            var (result, skills) = _parser.ParseGems(gems);
+            return (result.Modifiers, skills);
         }
 
         public Task<CalculatorUpdate> ParseSkillsAsync(IEnumerable<IReadOnlyList<Skill>> skills) =>

--- a/WPFSKillTree/Computation/Model/ComputationObservables.cs
+++ b/WPFSKillTree/Computation/Model/ComputationObservables.cs
@@ -80,10 +80,10 @@ namespace PoESkillTree.Computation.Model
                 : _parser.ParseJewelSocketedInItem(item, slot).Modifiers;
         }
 
-        public Task<(CalculatorUpdate update, IEnumerable<IReadOnlyList<Skill>> skills)> ParseGemsAsync(IEnumerable<IReadOnlyList<Gem>> gems) =>
+        public Task<(CalculatorUpdate update, IReadOnlyList<IReadOnlyList<Skill>> skills)> ParseGemsAsync(IEnumerable<IReadOnlyList<Gem>> gems) =>
             _parsingScheduler.ScheduleAsync(() => ParseGems(gems));
 
-        public (IObservable<CalculatorUpdate> updateObservable, IObservable<IEnumerable<IReadOnlyList<Skill>>> skillsObservable) ObserveGems(
+        public (IObservable<CalculatorUpdate> updateObservable, IObservable<IReadOnlyList<IReadOnlyList<Skill>>> skillsObservable) ObserveGems(
             INotifyCollectionChanged<IReadOnlyList<Gem>> gems)
         {
             var updateAndSkillsObservable = CreateObservableFromCollection(gems)
@@ -105,12 +105,12 @@ namespace PoESkillTree.Computation.Model
             return (updateObservable, skillsObservable);
         }
 
-        private (CalculatorUpdate, IEnumerable<IReadOnlyList<Skill>>) ParseGems(IEnumerable<IReadOnlyList<Gem>> gems)
+        private (CalculatorUpdate, IReadOnlyList<IReadOnlyList<Skill>>) ParseGems(IEnumerable<IReadOnlyList<Gem>> gems)
         {
             var modifiersAndSkills = gems.Select(ParseGems).ToList();
             var modifiers = modifiersAndSkills.SelectMany(t => t.modifiers).ToList();
             var calculatorUpdate = new CalculatorUpdate(modifiers, Array.Empty<Modifier>());
-            var skills = modifiersAndSkills.Select(t => t.skills);
+            var skills = modifiersAndSkills.Select(t => t.skills).ToList();
             return (calculatorUpdate, skills);
         }
 

--- a/WPFSKillTree/Computation/Model/ObservableCalculator.cs
+++ b/WPFSKillTree/Computation/Model/ObservableCalculator.cs
@@ -81,6 +81,9 @@ namespace PoESkillTree.Computation.Model
             => observable.ObserveOn(_calculationScheduler)
                 .ForEachAsync(UpdateCalculator);
 
+        public Task UpdateCalculatorAsync(Task<CalculatorUpdate> update) =>
+            _calculationScheduler.ScheduleAsync(async () => UpdateCalculator(await update.ConfigureAwait(false)));
+
         public void SubscribeTo(IObservable<CalculatorUpdate> observable)
             => _updateSubject.Value.OnNext(observable);
 

--- a/WPFSKillTree/Computation/Model/ObservableCalculator.cs
+++ b/WPFSKillTree/Computation/Model/ObservableCalculator.cs
@@ -106,8 +106,7 @@ namespace PoESkillTree.Computation.Model
             var subject = new Subject<IObservable<CalculatorUpdate>>();
             subject.Merge()
                 .Buffer(TimeSpan.FromMilliseconds(50))
-                .Where(us => us.Any())
-                .Select(us => us.Aggregate(CalculatorUpdate.Accumulate))
+                .Select(us => us.Aggregate(CalculatorUpdate.Empty, CalculatorUpdate.Accumulate))
                 .Where(u => u.AddedModifiers.Any() || u.RemovedModifiers.Any())
                 .ObserveOn(_calculationScheduler)
                 .Subscribe(UpdateCalculator, ex => Log.Error(ex, "Exception while observing calculator updates"));

--- a/WPFSKillTree/Computation/Model/ObservableCalculator.cs
+++ b/WPFSKillTree/Computation/Model/ObservableCalculator.cs
@@ -126,18 +126,14 @@ namespace PoESkillTree.Computation.Model
             => _calculator.NodeRepository.GetNode(stat, nodeType, path);
 
         public async Task<IEnumerable<(ICalculationNode node, Modifier modifier)>> GetFormNodeCollectionAsync(
-            IStat stat, Form form, PathDefinition path)
-            => await _calculator.NodeRepository.GetFormNodeCollection(stat, form, path)
-                .ToObservable().SubscribeOn(_calculationScheduler)
-                .ToList().SingleAsync();
+            IStat stat, Form form, PathDefinition path) =>
+            await _calculationScheduler.ScheduleAsync(() => _calculator.NodeRepository.GetFormNodeCollection(stat, form, path));
 
-        public async Task<IEnumerable<PathDefinition>> GetPathsAsync(IStat stat)
-            => await _calculator.NodeRepository.GetPaths(stat)
-                .ToObservable().SubscribeOn(_calculationScheduler)
-                .ToList().SingleAsync();
+        public async Task<IEnumerable<PathDefinition>> GetPathsAsync(IStat stat) =>
+            await _calculationScheduler.ScheduleAsync(() => _calculator.NodeRepository.GetPaths(stat));
 
         public IDisposable PeriodicallyRemoveUnusedNodes(Action<Exception> onError)
-            => Observable.Interval(TimeSpan.FromMilliseconds(250))
+            => Observable.Interval(TimeSpan.FromMilliseconds(250), _calculationScheduler)
                 .ObserveOn(_calculationScheduler)
                 .Subscribe(_ => _calculator.RemoveUnusedNodes(), onError);
     }

--- a/WPFSKillTree/Computation/ViewModels/ComputationViewModel.cs
+++ b/WPFSKillTree/Computation/ViewModels/ComputationViewModel.cs
@@ -66,6 +66,7 @@ namespace PoESkillTree.Computation.ViewModels
         private void InitializeOffensiveStats(IBuilderFactories f)
         {
             AddStats(OffensiveStats, f.MetaStatBuilders.SkillDpsWithHits);
+            AddStats(OffensiveStats, f.MetaStatBuilders.SkillDpsWithHitsCalculationMode);
             AddStats(OffensiveStats, f.MetaStatBuilders.SkillDpsWithDoTs);
             ForEachDamagingAilment(a => AddStats(OffensiveStats, f.MetaStatBuilders.AilmentDps(a)));
 

--- a/WPFSKillTree/Computation/ViewModels/MainSkillSelectionViewModel.cs
+++ b/WPFSKillTree/Computation/ViewModels/MainSkillSelectionViewModel.cs
@@ -125,7 +125,7 @@ namespace PoESkillTree.Computation.ViewModels
         }
 
         private bool IsActiveSkill(Skill skill)
-            => skill.IsEnabled && !_skillDefinitions.GetSkillById(skill.Id).IsSupport;
+            => skill.IsEnabled && (skill.Gem is null || skill.Gem.IsEnabled) && !_skillDefinitions.GetSkillById(skill.Id).IsSupport;
 
         private void AddSkill(MainSkillViewModel skill)
             => AvailableSkills.Add(skill);

--- a/WPFSKillTree/Computation/ViewModels/MainSkillSelectionViewModel.cs
+++ b/WPFSKillTree/Computation/ViewModels/MainSkillSelectionViewModel.cs
@@ -44,13 +44,13 @@ namespace PoESkillTree.Computation.ViewModels
             _skillDefinitions = skillDefinitions;
             var selectedSkillItemSlotStat = builderFactories.MetaStatBuilders.MainSkillItemSlot
                 .BuildToStats(Entity.Character).Single();
-            _selectedSkillItemSlot = nodeFactory.CreateConfiguration(selectedSkillItemSlotStat, new NodeValue(0));
+            _selectedSkillItemSlot = nodeFactory.CreateConfiguration(selectedSkillItemSlotStat, new NodeValue((int) Skill.Default.ItemSlot));
             var selectedSkillSocketIndexStat = builderFactories.MetaStatBuilders.MainSkillSocketIndex
                 .BuildToStats(Entity.Character).Single();
-            _selectedSkillSocketIndex = nodeFactory.CreateConfiguration(selectedSkillSocketIndexStat, new NodeValue(0));
+            _selectedSkillSocketIndex = nodeFactory.CreateConfiguration(selectedSkillSocketIndexStat, new NodeValue(Skill.Default.SocketIndex));
             var selectedSkillSkillIndexStat = builderFactories.MetaStatBuilders.MainSkillSkillIndex
                 .BuildToStats(Entity.Character).Single();
-            _selectedSkillSkillIndex = nodeFactory.CreateConfiguration(selectedSkillSkillIndexStat, new NodeValue(0));
+            _selectedSkillSkillIndex = nodeFactory.CreateConfiguration(selectedSkillSkillIndexStat, new NodeValue(Skill.Default.SkillIndex));
             var selectedSkillPartStat = builderFactories.StatBuilders.MainSkillPart
                 .BuildToStats(Entity.Character).Single();
             _selectedSkillPart = nodeFactory.CreateConfiguration(selectedSkillPartStat, new NodeValue(0));

--- a/WPFSKillTree/Computation/ViewModels/MainSkillSelectionViewModel.cs
+++ b/WPFSKillTree/Computation/ViewModels/MainSkillSelectionViewModel.cs
@@ -20,6 +20,7 @@ namespace PoESkillTree.Computation.ViewModels
         private readonly SkillDefinitions _skillDefinitions;
         private readonly ConfigurationNodeViewModel _selectedSkillItemSlot;
         private readonly ConfigurationNodeViewModel _selectedSkillSocketIndex;
+        private readonly ConfigurationNodeViewModel _selectedSkillSkillIndex;
         private readonly ConfigurationNodeViewModel _selectedSkillPart;
 
         private MainSkillViewModel _selectedSkill;
@@ -34,7 +35,7 @@ namespace PoESkillTree.Computation.ViewModels
             return vm;
         }
 
-#pragma warning disable CS8618 // SelectedSkill is initalized in Initialize and can't be set to null.
+#pragma warning disable CS8618 // SelectedSkill is initialized in Initialize and can't be set to null.
         private MainSkillSelectionViewModel(
 #pragma warning restore
             SkillDefinitions skillDefinitions, IBuilderFactories builderFactories,
@@ -47,10 +48,13 @@ namespace PoESkillTree.Computation.ViewModels
             var selectedSkillSocketIndexStat = builderFactories.MetaStatBuilders.MainSkillSocketIndex
                 .BuildToStats(Entity.Character).Single();
             _selectedSkillSocketIndex = nodeFactory.CreateConfiguration(selectedSkillSocketIndexStat, new NodeValue(0));
+            var selectedSkillSkillIndexStat = builderFactories.MetaStatBuilders.MainSkillSkillIndex
+                .BuildToStats(Entity.Character).Single();
+            _selectedSkillSkillIndex = nodeFactory.CreateConfiguration(selectedSkillSkillIndexStat, new NodeValue(0));
             var selectedSkillPartStat = builderFactories.StatBuilders.MainSkillPart
                 .BuildToStats(Entity.Character).Single();
             _selectedSkillPart = nodeFactory.CreateConfiguration(selectedSkillPartStat, new NodeValue(0));
-            ConfigurationNodes = new[] { _selectedSkillItemSlot, _selectedSkillSocketIndex, _selectedSkillPart };
+            ConfigurationNodes = new[] { _selectedSkillItemSlot, _selectedSkillSocketIndex, _selectedSkillSkillIndex, _selectedSkillPart };
         }
 
         private void Initialize(ObservableSet<IReadOnlyList<Skill>> skills)
@@ -59,6 +63,7 @@ namespace PoESkillTree.Computation.ViewModels
             SelectedSkill = GetSelectedAndAvailableSkill() ?? AvailableSkills.First();
             _selectedSkillItemSlot.PropertyChanged += OnSelectedSkillStatChanged;
             _selectedSkillSocketIndex.PropertyChanged += OnSelectedSkillStatChanged;
+            _selectedSkillSkillIndex.PropertyChanged += OnSelectedSkillStatChanged;
             skills.CollectionChanged += OnSkillsChanged;
         }
 
@@ -77,6 +82,7 @@ namespace PoESkillTree.Computation.ViewModels
                     return;
                 _selectedSkillItemSlot.NumericValue = (double?) value.Skill.ItemSlot;
                 _selectedSkillSocketIndex.NumericValue = value.Skill.SocketIndex;
+                _selectedSkillSkillIndex.NumericValue = value.Skill.SkillIndex;
                 SetProperty(ref _selectedSkill, value);
             }
         }
@@ -84,7 +90,8 @@ namespace PoESkillTree.Computation.ViewModels
         private MainSkillViewModel? GetSelectedAndAvailableSkill()
             => AvailableSkills.FirstOrDefault(
                 s => s.Skill.ItemSlot == (ItemSlot?) _selectedSkillItemSlot.NumericValue &&
-                     s.Skill.SocketIndex == (int?) _selectedSkillSocketIndex.NumericValue);
+                     s.Skill.SocketIndex == (int?) _selectedSkillSocketIndex.NumericValue &&
+                     s.Skill.SkillIndex == (int?) _selectedSkillSkillIndex.NumericValue);
 
         private void OnSelectedSkillStatChanged(object sender, PropertyChangedEventArgs args)
         {

--- a/WPFSKillTree/Model/Items/Item.cs
+++ b/WPFSKillTree/Model/Items/Item.cs
@@ -387,7 +387,7 @@ namespace PoESkillTree.Model.Items
                 level = (int) properties.First("Level: # (Max)", 0, 1);
             }
             var quality = (int) properties.First("Quality: +#%", 0, 0);
-            skill = new Skill(definition.Id, (int) level, quality, Slot, socketIndex, socketGroups[socketIndex]);
+            skill = Skill.FromGem(new Gem(definition.Id, (int) level, quality, Slot, socketIndex, socketGroups[socketIndex], true), true);
             return true;
         }
 

--- a/WPFSKillTree/Model/Items/ItemAttributes.cs
+++ b/WPFSKillTree/Model/Items/ItemAttributes.cs
@@ -6,7 +6,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PoESkillTree.Engine.GameModel.Items;
 using PoESkillTree.Engine.GameModel.Skills;
-using PoESkillTree.Engine.Utils;
 using PoESkillTree.Engine.Utils.Extensions;
 using PoESkillTree.Utils;
 
@@ -170,9 +169,7 @@ namespace PoESkillTree.Model.Items
             _skillDefinitions = skillDefinitions;
             Equip.CollectionChanged += OnCollectionChanged;
             Gems.CollectionChanged += OnCollectionChanged;
-            SkillEnabler.JsonRepresentationChanged += OnCollectionChanged;
-            Skills.Add(new[] {Skill.Default});
-            Skills.CollectionChanged += SkillsOnCollectionChanged;
+            SkillEnabler.EnabledChangedForSlots += OnCollectionChanged;
 
             if (!string.IsNullOrEmpty(itemData))
             {
@@ -309,17 +306,11 @@ namespace PoESkillTree.Model.Items
             }
             Equip.CollectionChanged -= OnCollectionChanged;
             Gems.CollectionChanged -= OnCollectionChanged;
-            SkillEnabler.JsonRepresentationChanged -= OnCollectionChanged;
-            Skills.CollectionChanged -= SkillsOnCollectionChanged;
+            SkillEnabler.EnabledChangedForSlots -= OnCollectionChanged;
         }
 
-        private void OnCollectionChanged(object? sender, EventArgs args)
+        private void OnCollectionChanged(object? sender, object args)
             => OnItemDataChanged();
-
-        private void SkillsOnCollectionChanged(object sender, CollectionChangedEventArgs<IReadOnlyList<Skill>> args)
-        {
-            SkillEnabler.Store(args.AddedItems, args.RemovedItems);
-        }
 
         private void SlottedItemOnPropertyChanged(object sender, PropertyChangedEventArgs args)
         {

--- a/WPFSKillTree/Model/Items/SkillEnabler.cs
+++ b/WPFSKillTree/Model/Items/SkillEnabler.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using PoESkillTree.Engine.GameModel.Items;
+using PoESkillTree.Engine.GameModel.Skills;
+using PoESkillTree.Engine.Utils;
+using PoESkillTree.Engine.Utils.Extensions;
+
+namespace PoESkillTree.Model.Items
+{
+    public class SkillEnabler
+    {
+        private readonly Dictionary<DictKey, bool> _enabledDict = new Dictionary<DictKey, bool>();
+
+        public Skill Apply(Skill skill)
+        {
+            if (_enabledDict.TryGetValue(new DictKey(skill), out var value) && value != skill.IsEnabled)
+            {
+                if (skill.Gem is null)
+                {
+                    return Skill.FromItem(skill.Id, skill.Level, skill.Quality, skill.ItemSlot, skill.SkillIndex, value);
+                }
+                else if (skill.SkillIndex > 0)
+                {
+                    return Skill.SecondaryFromGem(skill.Id, skill.Gem, value);
+                }
+                else
+                {
+                    return Skill.FromGem(skill.Gem, value);
+                }
+            }
+
+            return skill;
+        }
+
+        public void Store(IReadOnlyCollection<IReadOnlyList<Skill>> skillsToAdd, IReadOnlyCollection<IReadOnlyList<Skill>> skillsToRemove)
+        {
+            var storedKeys = new HashSet<DictKey>();
+            foreach (var skill in skillsToAdd.Flatten())
+            {
+                var key = new DictKey(skill);
+                _enabledDict[key] = skill.IsEnabled;
+                storedKeys.Add(key);
+            }
+            foreach (var skill in skillsToRemove.Flatten())
+            {
+                var key = new DictKey(skill);
+                if (!storedKeys.Contains(key))
+                {
+                    _enabledDict.Remove(key);
+                }
+            }
+            JsonRepresentationChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void SetIsEnabled(Gem gem, int skillIndex, bool isEnabled)
+        {
+            _enabledDict[new DictKey(gem, skillIndex)] = isEnabled;
+        }
+
+        public void FromJson(JToken json)
+        {
+            _enabledDict.Clear();
+            foreach (var representation in json.ToObject<JsonRepresentation[]>()!)
+            {
+                _enabledDict[new DictKey(representation)] = representation.IsEnabled;
+            }
+            JsonRepresentationChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public event EventHandler? JsonRepresentationChanged;
+
+        public string ToJsonString()
+        {
+            var representations = _enabledDict.Select(p => new JsonRepresentation
+            {
+                Id = p.Key.Tuple.id,
+                ItemSlot = p.Key.Tuple.itemSlot,
+                SocketIndex = p.Key.Tuple.socketIndex,
+                SkillIndex = p.Key.Tuple.skillIndex,
+                IsEnabled = p.Value
+            });
+            return JsonConvert.SerializeObject(representations);
+        }
+
+        private class DictKey : ValueObject
+        {
+            public DictKey(Skill skill)
+            {
+                Tuple = (skill.Gem?.SkillId ?? skill.Id, skill.ItemSlot, skill.SocketIndex, skill.SkillIndex);
+            }
+
+            public DictKey(Gem gem, int skillIndex)
+            {
+                Tuple = (gem.SkillId, gem.ItemSlot, gem.SocketIndex, skillIndex);
+            }
+
+            public DictKey(JsonRepresentation jsonRepresentation)
+            {
+                Tuple = (jsonRepresentation.Id, jsonRepresentation.ItemSlot, jsonRepresentation.SocketIndex, jsonRepresentation.SkillIndex);
+            }
+
+            public (string id, ItemSlot itemSlot, int socketIndex, int skillIndex) Tuple { get; }
+
+            protected override object ToTuple() => Tuple;
+        }
+
+        private class JsonRepresentation
+        {
+            public string Id { get; set; } = "";
+            public ItemSlot ItemSlot { get; set; }
+            public int SocketIndex { get; set; }
+            public int SkillIndex { get; set; }
+
+            public bool IsEnabled { get; set; }
+        }
+    }
+}

--- a/WPFSKillTree/Model/Items/SkillEnabler.cs
+++ b/WPFSKillTree/Model/Items/SkillEnabler.cs
@@ -17,18 +17,7 @@ namespace PoESkillTree.Model.Items
         {
             if (_enabledDict.TryGetValue(new DictKey(skill), out var value) && value != skill.IsEnabled)
             {
-                if (skill.Gem is null)
-                {
-                    return Skill.FromItem(skill.Id, skill.Level, skill.Quality, skill.ItemSlot, skill.SkillIndex, value);
-                }
-                else if (skill.SkillIndex > 0)
-                {
-                    return Skill.SecondaryFromGem(skill.Id, skill.Gem, value);
-                }
-                else
-                {
-                    return Skill.FromGem(skill.Gem, value);
-                }
+                return skill.WithIsEnabled(value);
             }
 
             return skill;

--- a/WPFSKillTree/Model/ObservableItemCollectionConverter.cs
+++ b/WPFSKillTree/Model/ObservableItemCollectionConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using PoESkillTree.Computation.Model;
 using PoESkillTree.Engine.GameModel.Items;
 using PoESkillTree.Engine.GameModel.Skills;
 using PoESkillTree.Engine.Utils;
@@ -27,9 +28,9 @@ namespace PoESkillTree.Model
         public ObservableSet<IReadOnlyList<Gem>> Gems { get; } = new ObservableSet<IReadOnlyList<Gem>>();
         public ObservableSkillCollection Skills { get; }
 
-        public ObservableItemCollectionConverter()
+        public ObservableItemCollectionConverter(AdditionalSkillStatApplier additionalSkillStatApplier)
         {
-            Skills = new ObservableSkillCollection(Gems);
+            Skills = new ObservableSkillCollection(Gems, additionalSkillStatApplier);
         }
 
         public void ConvertFrom(ItemAttributes itemAttributes)

--- a/WPFSKillTree/Model/ObservableSkillCollection.cs
+++ b/WPFSKillTree/Model/ObservableSkillCollection.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using PoESkillTree.Computation.Model;
 using PoESkillTree.Engine.GameModel.Items;
 using PoESkillTree.Engine.GameModel.Skills;
 using PoESkillTree.Engine.Utils;
@@ -14,13 +15,16 @@ namespace PoESkillTree.Model
         private ObservableSet<IReadOnlyList<Skill>>? _itemAttributesSkills;
 
         private readonly ObservableSet<IReadOnlyList<Gem>> _gems;
+        private readonly AdditionalSkillStatApplier _additionalSkillStatApplier;
 
         public ObservableSet<IReadOnlyList<Skill>> Collection { get; } = new ObservableSet<IReadOnlyList<Skill>>();
 
-        public ObservableSkillCollection(ObservableSet<IReadOnlyList<Gem>> gems)
+        public ObservableSkillCollection(ObservableSet<IReadOnlyList<Gem>> gems, AdditionalSkillStatApplier additionalSkillStatApplier)
         {
             _gems = gems;
-            Collection.CollectionChanged += SkillsOnCollectionChanged;
+            _additionalSkillStatApplier = additionalSkillStatApplier;
+            _additionalSkillStatApplier.StatChangedForSlot += AdditionalSkillStatApplierOnStatChangedForSlot;
+            Collection.CollectionChanged += OnCollectionChanged;
         }
 
         public void ConnectTo(ItemAttributes itemAttributes)
@@ -30,7 +34,7 @@ namespace PoESkillTree.Model
             _skillEnabler = itemAttributes.SkillEnabler;
             _itemAttributesSkills = itemAttributes.Skills;
 
-            Collection.ResetTo(GetDefaultSkills().Select(ApplyEnabler));
+            Collection.ResetTo(GetDefaultSkills().Select(Update));
             _itemAttributesSkills.ResetTo(Collection);
 
             _skillEnabler.EnabledChangedForSlots += SkillEnablerOnEnabledChangedForSlots;
@@ -38,7 +42,7 @@ namespace PoESkillTree.Model
 
         public void InitializeSkillsFromGems(IEnumerable<IReadOnlyList<Skill>> skills)
         {
-            Collection.ResetTo(skills.Concat(GetDefaultSkills()).Select(ApplyEnabler));
+            Collection.ResetTo(skills.Concat(GetDefaultSkills()).Select(Update));
         }
 
         public void UpdateSkillsFromGems(IReadOnlyList<IReadOnlyList<Skill>> toAdd)
@@ -48,26 +52,42 @@ namespace PoESkillTree.Model
             var toRemove = Collection
                 .Where(ss => !slotsWithGemsOrItemSkills.Contains(ss.First().ItemSlot) || changedSlots.Contains(ss.First().ItemSlot))
                 .ToList();
-            Collection.ExceptAndUnionWith(toRemove, toAdd.Select(ApplyEnabler));
+            Collection.ExceptAndUnionWith(toRemove, toAdd.Select(Update));
         }
 
         private static IEnumerable<IReadOnlyList<Skill>> GetDefaultSkills() =>
             new[] {new[] {Skill.Default}};
 
-        private IReadOnlyList<Skill> ApplyEnabler(IEnumerable<Skill> skills) =>
-            skills.Select(ApplyEnabler).ToList();
+        private IReadOnlyList<Skill> Update(IEnumerable<Skill> skills) =>
+            skills.Select(Update).ToList();
 
-        private Skill ApplyEnabler(Skill skill) =>
-            _skillEnabler?.Apply(skill) ?? skill;
+        private Skill Update(Skill skill)
+        {
+            if (_skillEnabler != null)
+            {
+                skill = _skillEnabler.Apply(skill);
+            }
+            return _additionalSkillStatApplier.Apply(skill);
+        }
 
-        private void SkillsOnCollectionChanged(
-            object sender, CollectionChangedEventArgs<IReadOnlyList<Skill>> args) =>
+        private void OnCollectionChanged(
+            object sender, CollectionChangedEventArgs<IReadOnlyList<Skill>> args)
+        {
+            _additionalSkillStatApplier.CleanSubscriptions(args.RemovedItems, args.AddedItems);
             _itemAttributesSkills?.ExceptAndUnionWith(args.RemovedItems, args.AddedItems);
+        }
 
         private void SkillEnablerOnEnabledChangedForSlots(object? sender, IReadOnlyCollection<ItemSlot> changedSlots)
         {
             var toRemove = Collection.Where(ss => changedSlots.Contains(ss.First().ItemSlot)).ToList();
-            var toAdd = toRemove.Select(ApplyEnabler);
+            var toAdd = toRemove.Select(Update);
+            Collection.ExceptAndUnionWith(toRemove, toAdd);
+        }
+
+        private void AdditionalSkillStatApplierOnStatChangedForSlot(object? sender, ItemSlot e)
+        {
+            var toRemove = Collection.Where(ss => ss.First().ItemSlot == e).ToList();
+            var toAdd = toRemove.Select(Update);
             Collection.ExceptAndUnionWith(toRemove, toAdd);
         }
     }

--- a/WPFSKillTree/Model/ObservableSkillCollection.cs
+++ b/WPFSKillTree/Model/ObservableSkillCollection.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using PoESkillTree.Engine.GameModel.Items;
+using PoESkillTree.Engine.GameModel.Skills;
+using PoESkillTree.Engine.Utils;
+using PoESkillTree.Model.Items;
+using PoESkillTree.Utils;
+
+namespace PoESkillTree.Model
+{
+    public class ObservableSkillCollection
+    {
+        private SkillEnabler? _skillEnabler;
+        private ObservableSet<IReadOnlyList<Skill>>? _itemAttributesSkills;
+
+        private readonly ObservableSet<IReadOnlyList<Gem>> _gems;
+
+        public ObservableSet<IReadOnlyList<Skill>> Collection { get; } = new ObservableSet<IReadOnlyList<Skill>>();
+
+        public ObservableSkillCollection(ObservableSet<IReadOnlyList<Gem>> gems)
+        {
+            _gems = gems;
+            Collection.CollectionChanged += SkillsOnCollectionChanged;
+        }
+
+        public void ConnectTo(ItemAttributes itemAttributes)
+        {
+            if (_skillEnabler != null)
+                _skillEnabler.EnabledChangedForSlots -= SkillEnablerOnEnabledChangedForSlots;
+            _skillEnabler = itemAttributes.SkillEnabler;
+            _itemAttributesSkills = itemAttributes.Skills;
+
+            Collection.ResetTo(GetDefaultSkills().Select(ApplyEnabler));
+            _itemAttributesSkills.ResetTo(Collection);
+
+            _skillEnabler.EnabledChangedForSlots += SkillEnablerOnEnabledChangedForSlots;
+        }
+
+        public void InitializeSkillsFromGems(IEnumerable<IReadOnlyList<Skill>> skills)
+        {
+            Collection.ResetTo(skills.Concat(GetDefaultSkills()).Select(ApplyEnabler));
+        }
+
+        public void UpdateSkillsFromGems(IReadOnlyList<IReadOnlyList<Skill>> toAdd)
+        {
+            var slotsWithGemsOrItemSkills = _gems.Select(gs => gs.First().ItemSlot).Append(Skill.Default.ItemSlot).ToHashSet();
+            var changedSlots = toAdd.Select(ss => ss.First().ItemSlot);
+            var toRemove = Collection
+                .Where(ss => !slotsWithGemsOrItemSkills.Contains(ss.First().ItemSlot) || changedSlots.Contains(ss.First().ItemSlot))
+                .ToList();
+            Collection.ExceptAndUnionWith(toRemove, toAdd.Select(ApplyEnabler));
+        }
+
+        private static IEnumerable<IReadOnlyList<Skill>> GetDefaultSkills() =>
+            new[] {new[] {Skill.Default}};
+
+        private IReadOnlyList<Skill> ApplyEnabler(IEnumerable<Skill> skills) =>
+            skills.Select(ApplyEnabler).ToList();
+
+        private Skill ApplyEnabler(Skill skill) =>
+            _skillEnabler?.Apply(skill) ?? skill;
+
+        private void SkillsOnCollectionChanged(
+            object sender, CollectionChangedEventArgs<IReadOnlyList<Skill>> args) =>
+            _itemAttributesSkills?.ExceptAndUnionWith(args.RemovedItems, args.AddedItems);
+
+        private void SkillEnablerOnEnabledChangedForSlots(object? sender, IReadOnlyCollection<ItemSlot> changedSlots)
+        {
+            var toRemove = Collection.Where(ss => changedSlots.Contains(ss.First().ItemSlot)).ToList();
+            var toAdd = toRemove.Select(ApplyEnabler);
+            Collection.ExceptAndUnionWith(toRemove, toAdd);
+        }
+    }
+}

--- a/WPFSKillTree/Model/Serialization/PathOfBuilding/PathOfBuildingImporter.cs
+++ b/WPFSKillTree/Model/Serialization/PathOfBuilding/PathOfBuildingImporter.cs
@@ -94,7 +94,7 @@ namespace PoESkillTree.Model.Serialization.PathOfBuilding
                 foreach (var xmlGem in xmlSkill.Gems)
                 {
                     var isEnabled = xmlSkill.Enabled && xmlGem.Enabled;
-                    yield return new Skill(xmlGem.SkillId, xmlGem.Level, xmlGem.Quality, slot, socketIndex, gemGroup, isEnabled);
+                    yield return Skill.FromGem(new Gem(xmlGem.SkillId, xmlGem.Level, xmlGem.Quality, slot, socketIndex, gemGroup, isEnabled), true);
                     socketIndex++;
                 }
 

--- a/WPFSKillTree/Model/Serialization/PathOfBuilding/XmlPathOfBuilding.cs
+++ b/WPFSKillTree/Model/Serialization/PathOfBuilding/XmlPathOfBuilding.cs
@@ -61,6 +61,10 @@ namespace PoESkillTree.Model.Serialization.PathOfBuilding
         public bool Enabled { get; set; }
         [XmlAttribute("skillPart")]
         public int SkillPart { get; set; }
+        [XmlAttribute("enableGlobal1")]
+        public bool PrimarySkillEnabled { get; set; } = true;
+        [XmlAttribute("enableGlobal2")]
+        public bool SecondarySkillEnabled { get; set; } = true;
     }
 
     public class XmlPathOfBuildingTree

--- a/WPFSKillTree/ViewModels/Import/ImportCharacterViewModel.cs
+++ b/WPFSKillTree/ViewModels/Import/ImportCharacterViewModel.cs
@@ -213,17 +213,13 @@ namespace PoESkillTree.ViewModels.Import
             }
             if (importSkills)
             {
-                var toRemove = _itemAttributes.Skills.Where(ss => ss.First().ItemSlot != ItemSlot.Unequipable).ToList();
-                foreach (var skills in toRemove)
-                {
-                    _itemAttributes.RemoveSkills(skills);
-                }
+                _itemAttributes.Gems.Clear();
             }
 
             var importJson = JObject.Parse(importString);
             if (importItems || importSkills)
             {
-                _itemAttributes.DeserializeItemsWithSkills(importJson, importItems, importSkills);
+                _itemAttributes.DeserializeItemsWithGems(importJson, importItems, importSkills);
             }
             if (importLevel && importJson.TryGetValue("character", out var characterToken))
             {

--- a/WPFSKillTree/ViewModels/Skills/GemViewModel.cs
+++ b/WPFSKillTree/ViewModels/Skills/GemViewModel.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using PoESkillTree.Engine.GameModel.Items;
+using PoESkillTree.Engine.GameModel.Skills;
+using PoESkillTree.Model.Items;
+using PoESkillTree.Utils;
+
+namespace PoESkillTree.ViewModels.Skills
+{
+    public class GemViewModel : Notifier
+    {
+        private int _level;
+        private int _quality;
+        private int _group;
+        private int _socketIndex;
+        private SkillDefinitionViewModel? _definition;
+        private IReadOnlyList<SkillViewModel> _skills = Array.Empty<SkillViewModel>();
+        private bool _isEnabled;
+        private IHasItemToolTip _toolTip;
+
+        public GemViewModel(SkillDefinitionViewModel? definition)
+        {
+            _definition = definition;
+            _toolTip = CreateToolTip();
+        }
+
+        /// <summary>
+        /// Gets or sets the level of this skill.
+        /// </summary>
+        public int Level
+        {
+            get => _level;
+            set => SetProperty(ref _level, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the quality of this skill (in percent).
+        /// </summary>
+        public int Quality
+        {
+            get => _quality;
+            set => SetProperty(ref _quality, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the socket group this gems is in. Gems of the same group are linked.
+        /// </summary>
+        public int Group
+        {
+            get => _group;
+            set => SetProperty(ref _group, value);
+        }
+
+        public int SocketIndex
+        {
+            get => _socketIndex;
+            set => SetProperty(ref _socketIndex, value);
+        }
+
+        public SkillDefinitionViewModel? Definition
+        {
+            get => _definition;
+            set => SetProperty(ref _definition, value);
+        }
+
+        public IReadOnlyList<SkillViewModel> Skills
+        {
+            get => _skills;
+            set => SetProperty(ref _skills, value);
+        }
+
+        public bool IsEnabled
+        {
+            get => _isEnabled;
+            set => SetProperty(ref _isEnabled, value);
+        }
+
+        public string DisplayName => Definition?.Model.DisplayName ?? "";
+
+        public IHasItemToolTip ToolTip
+        {
+            get => _toolTip;
+            private set => SetProperty(ref _toolTip, value);
+        }
+
+        public GemViewModel Clone() =>
+            new GemViewModel(Definition)
+            {
+                Group = Group,
+                SocketIndex = SocketIndex,
+                Quality = Quality,
+                Level = Level,
+                Skills = Skills,
+                IsEnabled = IsEnabled,
+                ToolTip = ToolTip,
+            };
+
+        public Gem ToGem(ItemSlot slot)
+        {
+            if (Definition is null)
+                throw new InvalidOperationException("Can only convert GemViewModels with Definitions to Gems");
+            return new Gem(Definition.Id, Level, Quality, slot, SocketIndex, Group, IsEnabled);
+        }
+
+        protected override void OnPropertyChanged(string propertyName)
+        {
+            if (propertyName == nameof(Definition) && Level > Definition?.MaxLevel)
+            {
+                Level = Definition.MaxLevel;
+            }
+            if (propertyName == nameof(Definition) || propertyName == nameof(Level) || propertyName == nameof(Quality)
+                || propertyName == nameof(Skills))
+            {
+                // TODO recreate ToolTips of all Skills
+                ToolTip = CreateToolTip();
+            }
+            base.OnPropertyChanged(propertyName);
+        }
+
+        private IHasItemToolTip CreateToolTip()
+        {
+            // TODO use ToolTip of first Skill
+            if (Definition != null && Definition.Model.Levels.TryGetValue(Level, out var levelDefinition))
+            {
+                return new SkillItem(levelDefinition.Tooltip, Quality);
+            }
+            else
+            {
+                return new SkillItem(DisplayName);
+            }
+        }
+    }
+}

--- a/WPFSKillTree/ViewModels/Skills/GemViewModel.cs
+++ b/WPFSKillTree/ViewModels/Skills/GemViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using PoESkillTree.Engine.GameModel.Items;
 using PoESkillTree.Engine.GameModel.Skills;
 using PoESkillTree.Model.Items;
@@ -111,23 +112,16 @@ namespace PoESkillTree.ViewModels.Skills
             if (propertyName == nameof(Definition) || propertyName == nameof(Level) || propertyName == nameof(Quality)
                 || propertyName == nameof(Skills))
             {
-                // TODO recreate ToolTips of all Skills
+                foreach (var skill in Skills)
+                {
+                    skill.ReCreateToolTip();
+                }
                 ToolTip = CreateToolTip();
             }
             base.OnPropertyChanged(propertyName);
         }
 
-        private IHasItemToolTip CreateToolTip()
-        {
-            // TODO use ToolTip of first Skill
-            if (Definition != null && Definition.Model.Levels.TryGetValue(Level, out var levelDefinition))
-            {
-                return new SkillItem(levelDefinition.Tooltip, Quality);
-            }
-            else
-            {
-                return new SkillItem(DisplayName);
-            }
-        }
+        private IHasItemToolTip CreateToolTip() =>
+            Skills.FirstOrDefault()?.ToolTip ?? new SkillItem(DisplayName);
     }
 }

--- a/WPFSKillTree/ViewModels/Skills/GemViewModel.cs
+++ b/WPFSKillTree/ViewModels/Skills/GemViewModel.cs
@@ -67,8 +67,10 @@ namespace PoESkillTree.ViewModels.Skills
         public IReadOnlyList<SkillViewModel> Skills
         {
             get => _skills;
-            set => SetProperty(ref _skills, value);
+            set => SetProperty(ref _skills, value, () => OnPropertyChanged(nameof(DisplaySkills)));
         }
+
+        public bool DisplaySkills => Skills.Count(s => !s.Definition.Model.IsSupport) > 1;
 
         public bool IsEnabled
         {

--- a/WPFSKillTree/ViewModels/Skills/SkillViewModel.cs
+++ b/WPFSKillTree/ViewModels/Skills/SkillViewModel.cs
@@ -5,58 +5,21 @@ namespace PoESkillTree.ViewModels.Skills
 {
     public class SkillViewModel : Notifier
     {
-        private int _level;
-        private int _quality;
-        private int? _gemGroup;
-        private int _socketIndex;
-        private SkillDefinitionViewModel? _definition;
         private bool _isEnabled;
-        private IHasItemToolTip _toolTip;
 
-        public SkillViewModel(SkillDefinitionViewModel? definition)
+        public SkillViewModel(GemViewModel? gem, int skillIndex, SkillDefinitionViewModel definition)
         {
-            _definition = definition;
-            _toolTip = CreateToolTip();
+            Gem = gem;
+            SkillIndex = skillIndex;
+            Definition = definition;
+            ToolTip = CreateToolTip();
         }
 
-        /// <summary>
-        /// Gets or sets the level of this skill.
-        /// </summary>
-        public int Level
-        {
-            get => _level;
-            set => SetProperty(ref _level, value);
-        }
+        public GemViewModel? Gem { get; }
 
-        /// <summary>
-        /// Gets or sets the quality of this skill (in percent).
-        /// </summary>
-        public int Quality
-        {
-            get => _quality;
-            set => SetProperty(ref _quality, value);
-        }
+        public int SkillIndex { get; }
 
-        /// <summary>
-        /// Gets or sets the socket group this skill is in. skill of the same group are linked.
-        /// </summary>
-        public int? GemGroup
-        {
-            get => _gemGroup;
-            set => SetProperty(ref _gemGroup, value);
-        }
-
-        public int SocketIndex
-        {
-            get => _socketIndex;
-            set => SetProperty(ref _socketIndex, value);
-        }
-
-        public SkillDefinitionViewModel? Definition
-        {
-            get => _definition;
-            set => SetProperty(ref _definition, value);
-        }
+        public SkillDefinitionViewModel Definition { get; }
 
         public bool IsEnabled
         {
@@ -64,53 +27,21 @@ namespace PoESkillTree.ViewModels.Skills
             set => SetProperty(ref _isEnabled, value);
         }
 
-        public string DisplayName
-        {
-            get
-            {
-                if (Definition is null)
-                    return "";
-                return Definition.Model.IsSupport
-                    ? Definition.Model.BaseItem?.DisplayName ?? ""
-                    : Definition.Model.ActiveSkill.DisplayName;
-            }
-        }
+        public string DisplayName => Definition.Model.DisplayName ?? "";
 
-        public IHasItemToolTip ToolTip
-        {
-            get => _toolTip;
-            private set => SetProperty(ref _toolTip, value);
-        }
+        public IHasItemToolTip ToolTip { get; }
 
         public SkillViewModel Clone() =>
-            new SkillViewModel(Definition)
+            new SkillViewModel(Gem, SkillIndex, Definition)
             {
-                GemGroup = GemGroup,
-                SocketIndex = SocketIndex,
-                Quality = Quality,
-                Level = Level,
                 IsEnabled = IsEnabled,
-                ToolTip = ToolTip,
             };
-
-        protected override void OnPropertyChanged(string propertyName)
-        {
-            if (propertyName == nameof(Definition) && Level > Definition?.MaxLevel)
-            {
-                Level = Definition.MaxLevel;
-            }
-            if (propertyName != nameof(ToolTip))
-            {
-                ToolTip = CreateToolTip();
-            }
-            base.OnPropertyChanged(propertyName);
-        }
 
         private IHasItemToolTip CreateToolTip()
         {
-            if (Definition != null && Definition.Model.Levels.TryGetValue(Level, out var levelDefinition))
+            if (Gem != null && Definition.Model.Levels.TryGetValue(Gem.Level, out var levelDefinition))
             {
-                return new SkillItem(levelDefinition.Tooltip, Quality);
+                return new SkillItem(levelDefinition.Tooltip, Gem.Quality);
             }
             else
             {

--- a/WPFSKillTree/ViewModels/Skills/SkillViewModel.cs
+++ b/WPFSKillTree/ViewModels/Skills/SkillViewModel.cs
@@ -6,13 +6,14 @@ namespace PoESkillTree.ViewModels.Skills
     public class SkillViewModel : Notifier
     {
         private bool _isEnabled;
+        private IHasItemToolTip _toolTip;
 
         public SkillViewModel(GemViewModel? gem, int skillIndex, SkillDefinitionViewModel definition)
         {
             Gem = gem;
             SkillIndex = skillIndex;
             Definition = definition;
-            ToolTip = CreateToolTip();
+            _toolTip = CreateToolTip();
         }
 
         public GemViewModel? Gem { get; }
@@ -29,13 +30,22 @@ namespace PoESkillTree.ViewModels.Skills
 
         public string DisplayName => Definition.Model.DisplayName ?? "";
 
-        public IHasItemToolTip ToolTip { get; }
+        public IHasItemToolTip ToolTip
+        {
+            get => _toolTip;
+            private set => SetProperty(ref _toolTip, value);
+        }
 
         public SkillViewModel Clone() =>
             new SkillViewModel(Gem, SkillIndex, Definition)
             {
                 IsEnabled = IsEnabled,
             };
+
+        public void ReCreateToolTip()
+        {
+            ToolTip = CreateToolTip();
+        }
 
         private IHasItemToolTip CreateToolTip()
         {

--- a/WPFSKillTree/ViewModels/Skills/SkillsInSlotEditingViewModel.cs
+++ b/WPFSKillTree/ViewModels/Skills/SkillsInSlotEditingViewModel.cs
@@ -199,10 +199,16 @@ namespace PoESkillTree.ViewModels.Skills
 
         private void GemViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs args)
         {
-            if (args.PropertyName != nameof(GemViewModel.Skills) && args.PropertyName != nameof(GemViewModel.ToolTip))
+            if (args.PropertyName == nameof(GemViewModel.Definition)
+                || args.PropertyName == nameof(GemViewModel.Level)
+                || args.PropertyName == nameof(GemViewModel.Quality)
+                || args.PropertyName == nameof(GemViewModel.SocketIndex)
+                || args.PropertyName == nameof(GemViewModel.Group)
+                || args.PropertyName == nameof(GemViewModel.IsEnabled))
             {
                 UpdateItemAttributes();
             }
+
             if (args.PropertyName == nameof(GemViewModel.Group) || args.PropertyName == nameof(GemViewModel.SocketIndex))
             {
                 GemsViewSource.View.Refresh();

--- a/WPFSKillTree/ViewModels/Skills/SkillsInSlotEditingViewModel.cs
+++ b/WPFSKillTree/ViewModels/Skills/SkillsInSlotEditingViewModel.cs
@@ -26,32 +26,33 @@ namespace PoESkillTree.ViewModels.Skills
     /// </summary>
     public sealed class SkillsInSlotEditingViewModel : CloseableViewModel, IDisposable
     {
+        private readonly SkillDefinitions _skillDefinitions;
+        private readonly ItemImageService _itemImageService;
         private readonly ItemAttributes _itemAttributes;
         public ItemSlot Slot { get; }
 
-        public IReadOnlyList<SkillDefinitionViewModel> AvailableSkills { get; }
+        public IReadOnlyList<SkillDefinitionViewModel> AvailableGems { get; }
 
-        public CollectionViewSource SkillsViewSource { get; }
+        public CollectionViewSource GemsViewSource { get; }
 
-        private readonly ObservableCollection<SkillViewModel> _skills
-            = new ObservableCollection<SkillViewModel>();
+        private readonly ObservableCollection<GemViewModel> _gems = new ObservableCollection<GemViewModel>();
 
-        private IReadOnlyList<Skill>? _skillModels;
+        private IReadOnlyList<Gem>? _gemModels;
 
-        public ICommand AddSkillCommand { get; }
-        public ICommand RemoveSkillCommand { get; }
+        public ICommand AddGemCommand { get; }
+        public ICommand RemoveGemCommand { get; }
 
         public int NumberOfSockets
             => _itemAttributes.GetItemInSlot(Slot, null)?.BaseType.MaximumNumberOfSockets ?? 0;
 
-        private SkillViewModel _newSkill;
+        private GemViewModel _newGem;
         /// <summary>
-        /// Gets the currently edited skill that can be socketed into the item with AddSkillCommand.
+        /// Gets the currently edited gem that can be socketed into the item with AddGemCommand.
         /// </summary>
-        public SkillViewModel NewSkill
+        public GemViewModel NewGem
         {
-            get => _newSkill;
-            private set => SetProperty(ref _newSkill, value);
+            get => _newGem;
+            private set => SetProperty(ref _newGem, value);
         }
 
         private static readonly string DefaultSummary = L10n.Message("no active skills");
@@ -76,135 +77,169 @@ namespace PoESkillTree.ViewModels.Skills
             SkillDefinitions skillDefinitions, ItemImageService itemImageService, ItemAttributes itemAttributes,
             ItemSlot slot)
         {
+            _skillDefinitions = skillDefinitions;
+            _itemImageService = itemImageService;
             _itemAttributes = itemAttributes;
             Slot = slot;
-            AvailableSkills = skillDefinitions.Skills
+            AvailableGems = skillDefinitions.Skills
                 .Where(d => d.BaseItem != null)
                 .Where(d => d.BaseItem!.ReleaseState == ReleaseState.Released ||
                             d.BaseItem.ReleaseState == ReleaseState.Legacy)
                 .OrderBy(d => d.BaseItem!.DisplayName)
-                .Select(d => new SkillDefinitionViewModel(itemImageService, d)).ToList();
-            _newSkill = new SkillViewModel(AvailableSkills[0])
+                .Select(CreateSkillDefinitionViewModel).ToList();
+            _newGem = new GemViewModel(AvailableGems[0])
             {
                 Level = 20,
                 Quality = 0,
-                GemGroup = 1,
+                Group = 1,
                 SocketIndex = -1,
                 IsEnabled = true,
             };
-            AddSkillCommand = new RelayCommand(AddSkill);
-            RemoveSkillCommand = new RelayCommand<SkillViewModel>(RemoveSkill);
+            AddGemCommand = new RelayCommand(AddGem);
+            RemoveGemCommand = new RelayCommand<GemViewModel>(RemoveGem);
 
-            SkillsViewSource = new CollectionViewSource
+            GemsViewSource = new CollectionViewSource
             {
-                Source = _skills
+                Source = _gems
             };
-            SkillsViewSource.SortDescriptions.Add(new SortDescription(
-                nameof(SkillViewModel.GemGroup),
+            GemsViewSource.SortDescriptions.Add(new SortDescription(
+                nameof(GemViewModel.Group),
                 ListSortDirection.Ascending));
-            SkillsViewSource.SortDescriptions.Add(new SortDescription(
-                nameof(SkillViewModel.SocketIndex),
+            GemsViewSource.SortDescriptions.Add(new SortDescription(
+                nameof(GemViewModel.SocketIndex),
                 ListSortDirection.Ascending));
 
-            UpdateFromItemAttributes();
+            UpdateGemsFromItemAttributes();
+            UpdateSkillsFromItemAttributes();
+            itemAttributes.Gems.CollectionChanged += GemsOnCollectionChanged;
             itemAttributes.Skills.CollectionChanged += SkillsOnCollectionChanged;
         }
 
-        private void UpdateFromItemAttributes()
+        private void UpdateGemsFromItemAttributes()
         {
-            _skills.Clear();
-            _skillModels = _itemAttributes.GetSkillsInSlot(Slot);
-            foreach (var skill in _skillModels)
+            foreach (var gemVm in _gems)
             {
-                var gemBase = AvailableSkills.FirstOrDefault(g => g.Id == skill.Id);
-                if (gemBase == null)
-                {
-                    continue;
-                }
-                var socketedGem = new SkillViewModel(gemBase)
-                {
-                    Level = skill.Level,
-                    Quality = skill.Quality,
-                    GemGroup = skill.Gem?.Group + 1,
-                    SocketIndex = skill.SocketIndex,
-                    IsEnabled = skill.IsEnabled,
-                };
-                socketedGem.PropertyChanged += SocketedGemsOnPropertyChanged;
-                _skills.Add(socketedGem);
+                DisposeGem(gemVm);
             }
+            _gems.Clear();
+
+            _gemModels = _itemAttributes.GetGemsInSlot(Slot);
+            foreach (var gem in _gemModels)
+            {
+                var definition = AvailableGems.FirstOrDefault(d => d.Id == gem.SkillId);
+                if (definition is null)
+                    continue;
+
+                var gemVm = new GemViewModel(definition)
+                {
+                    Level = gem.Level,
+                    Quality = gem.Quality,
+                    Group = gem.Group,
+                    SocketIndex = gem.SocketIndex,
+                    IsEnabled = gem.IsEnabled,
+                };
+                gemVm.PropertyChanged += GemViewModelOnPropertyChanged;
+                _gems.Add(gemVm);
+            }
+
             UpdateSummary();
         }
 
-        private void AddSkill()
+        private void UpdateSkillsFromItemAttributes()
         {
-            var addedGem = NewSkill.Clone();
-            addedGem.PropertyChanged += SocketedGemsOnPropertyChanged;
-            _skills.Add(addedGem);
-            UpdateItemAttributes();
-        }
-
-        private void RemoveSkill(SkillViewModel skill)
-        {
-            skill.PropertyChanged -= SocketedGemsOnPropertyChanged;
-            _skills.Remove(skill);
-            NewSkill = skill;
-            UpdateItemAttributes();
-        }
-
-        private void SocketedGemsOnPropertyChanged(object sender, PropertyChangedEventArgs args)
-        {
-            if (args.PropertyName != nameof(SkillViewModel.SocketIndex))
+            var skillModels = _itemAttributes.GetSkillsInSlot(Slot);
+            foreach (var (gem, skills) in skillModels.Where(s => s.Gem != null).GroupBy(s => s.Gem!))
             {
-                UpdateItemAttributes();
+                var gemVm = _gems.FirstOrDefault(v => v.Definition?.Id == gem.SkillId && v.SocketIndex == gem.SocketIndex);
+                if (gemVm is null)
+                    continue;
+
+                foreach (var skillVm in gemVm.Skills)
+                {
+                    skillVm.PropertyChanged -= SkillViewModelOnPropertyChanged;
+                }
+
+                var skillVms = new List<SkillViewModel>();
+                foreach (var skill in skills)
+                {
+                    var definition = CreateSkillDefinitionViewModel(_skillDefinitions.GetSkillById(skill.Id));
+                    var skillVm = new SkillViewModel(gemVm, skill.SkillIndex, definition);
+                    skillVm.PropertyChanged += SkillViewModelOnPropertyChanged;
+                    skillVms.Add(skillVm);
+                }
+                gemVm.Skills = skillVms;
             }
-            if (args.PropertyName == nameof(SkillViewModel.GemGroup) || args.PropertyName == nameof(SkillViewModel.SocketIndex))
+        }
+
+        private SkillDefinitionViewModel CreateSkillDefinitionViewModel(SkillDefinition definition) =>
+            new SkillDefinitionViewModel(_itemImageService, definition);
+
+        private void AddGem()
+        {
+            var addedGem = NewGem.Clone();
+            if (addedGem.SocketIndex < 0)
             {
-                SkillsViewSource.View.Refresh();
+                addedGem.SocketIndex = _gems.Max(g => g.SocketIndex) + 1;
+            }
+            addedGem.PropertyChanged += GemViewModelOnPropertyChanged;
+            _gems.Add(addedGem);
+            UpdateItemAttributes();
+        }
+
+        private void RemoveGem(GemViewModel gem)
+        {
+            DisposeGem(gem);
+            _gems.Remove(gem);
+            NewGem = gem;
+            UpdateItemAttributes();
+        }
+
+        private void GemViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs args)
+        {
+            UpdateItemAttributes();
+            if (args.PropertyName == nameof(GemViewModel.Group) || args.PropertyName == nameof(GemViewModel.SocketIndex))
+            {
+                GemsViewSource.View.Refresh();
+            }
+        }
+
+        private void SkillViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs args)
+        {
+            if (args.PropertyName == nameof(SkillViewModel.IsEnabled) && sender is SkillViewModel skillVm && skillVm.Gem != null)
+            {
+                _itemAttributes.SkillEnabler.SetIsEnabled(skillVm.Gem.ToGem(Slot), skillVm.SkillIndex, skillVm.IsEnabled);
             }
         }
 
         private void UpdateItemAttributes()
         {
-            var nextSocketIndex = _skills.Max(s => (int?) s.SocketIndex) + 1 ?? 0;
-            var skills = new List<Skill>();
-            foreach (var skillVm in _skills)
-            {
-                if (skillVm.SocketIndex < 0)
-                {
-                    skillVm.SocketIndex = nextSocketIndex++;
-                }
-                if (skillVm.Definition is null)
-                    continue;
-                Skill skill;
-                if (skillVm.GemGroup is null)
-                {
-                    skill = Skill.FromItem(skillVm.Definition.Id, skillVm.Level, skillVm.Quality, Slot,
-                        skillVm.SocketIndex, skillVm.IsEnabled);
-                }
-                else
-                {
-                    skill = Skill.FromGem(new Gem(skillVm.Definition.Id, skillVm.Level, skillVm.Quality, Slot,
-                        skillVm.SocketIndex, skillVm.GemGroup.Value - 1, skillVm.IsEnabled), true);
-                }
-                skills.Add(skill);
-            }
-
-            _skillModels = skills;
-            _itemAttributes.SetSkillsInSlot(_skillModels, Slot);
+            _gemModels = _gems
+                .Where(g => g.Definition != null)
+                .Select(g => g.ToGem(Slot))
+                .ToList();
+            _itemAttributes.SetGemsInSlot(_gemModels, Slot);
             UpdateSummary();
+        }
+
+        private void GemsOnCollectionChanged(object sender, CollectionChangedEventArgs<IReadOnlyList<Gem>> args)
+        {
+            if (!ReferenceEquals(_gemModels, _itemAttributes.GetGemsInSlot(Slot)))
+            {
+                UpdateGemsFromItemAttributes();
+            }
         }
 
         private void SkillsOnCollectionChanged(object sender, CollectionChangedEventArgs<IReadOnlyList<Skill>> args)
         {
-            if (!ReferenceEquals(_skillModels, _itemAttributes.GetSkillsInSlot(Slot)))
+            if (args.AddedItems.Concat(args.RemovedItems).Flatten().Any(s => s.ItemSlot == Slot))
             {
-                UpdateFromItemAttributes();
+                UpdateSkillsFromItemAttributes();
             }
         }
 
         private void UpdateSummary()
         {
-            var activeSkills = _skills
+            var activeSkills = _gems
                 .Where(s => s.Definition != null)
                 .Where(s => !s.Definition!.Model.IsSupport)
                 .ToList();
@@ -225,8 +260,18 @@ namespace PoESkillTree.ViewModels.Skills
             }
         }
 
+        private void DisposeGem(GemViewModel gem)
+        {
+            gem.PropertyChanged -= GemViewModelOnPropertyChanged;
+            foreach (var skill in gem.Skills)
+            {
+                skill.PropertyChanged -= SkillViewModelOnPropertyChanged;
+            }
+        }
+
         public void Dispose()
         {
+            _itemAttributes.Gems.CollectionChanged -= GemsOnCollectionChanged;
             _itemAttributes.Skills.CollectionChanged -= SkillsOnCollectionChanged;
         }
     }

--- a/WPFSKillTree/ViewModels/Skills/SkillsInSlotEditingViewModel.cs
+++ b/WPFSKillTree/ViewModels/Skills/SkillsInSlotEditingViewModel.cs
@@ -163,7 +163,10 @@ namespace PoESkillTree.ViewModels.Skills
                 foreach (var skill in skills)
                 {
                     var definition = CreateSkillDefinitionViewModel(_skillDefinitions.GetSkillById(skill.Id));
-                    var skillVm = new SkillViewModel(gemVm, skill.SkillIndex, definition);
+                    var skillVm = new SkillViewModel(gemVm, skill.SkillIndex, definition)
+                    {
+                        IsEnabled = skill.IsEnabled
+                    };
                     skillVm.PropertyChanged += SkillViewModelOnPropertyChanged;
                     skillVms.Add(skillVm);
                 }
@@ -179,7 +182,7 @@ namespace PoESkillTree.ViewModels.Skills
             var addedGem = NewGem.Clone();
             if (addedGem.SocketIndex < 0)
             {
-                addedGem.SocketIndex = _gems.Max(g => g.SocketIndex) + 1;
+                addedGem.SocketIndex = _gems.Any() ? _gems.Max(g => g.SocketIndex) + 1 : 1;
             }
             addedGem.PropertyChanged += GemViewModelOnPropertyChanged;
             _gems.Add(addedGem);
@@ -196,7 +199,10 @@ namespace PoESkillTree.ViewModels.Skills
 
         private void GemViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs args)
         {
-            UpdateItemAttributes();
+            if (args.PropertyName != nameof(GemViewModel.Skills) && args.PropertyName != nameof(GemViewModel.ToolTip))
+            {
+                UpdateItemAttributes();
+            }
             if (args.PropertyName == nameof(GemViewModel.Group) || args.PropertyName == nameof(GemViewModel.SocketIndex))
             {
                 GemsViewSource.View.Refresh();

--- a/WPFSKillTree/ViewModels/Skills/SkillsInSlotEditingViewModel.cs
+++ b/WPFSKillTree/ViewModels/Skills/SkillsInSlotEditingViewModel.cs
@@ -125,7 +125,7 @@ namespace PoESkillTree.ViewModels.Skills
                 {
                     Level = skill.Level,
                     Quality = skill.Quality,
-                    GemGroup = skill.GemGroup + 1,
+                    GemGroup = skill.Gem?.Group + 1,
                     SocketIndex = skill.SocketIndex,
                     IsEnabled = skill.IsEnabled,
                 };
@@ -175,8 +175,17 @@ namespace PoESkillTree.ViewModels.Skills
                 }
                 if (skillVm.Definition is null)
                     continue;
-                var skill = new Skill(skillVm.Definition.Id, skillVm.Level, skillVm.Quality, Slot,
-                    skillVm.SocketIndex, skillVm.GemGroup - 1, skillVm.IsEnabled);
+                Skill skill;
+                if (skillVm.GemGroup is null)
+                {
+                    skill = Skill.FromItem(skillVm.Definition.Id, skillVm.Level, skillVm.Quality, Slot,
+                        skillVm.SocketIndex, skillVm.IsEnabled);
+                }
+                else
+                {
+                    skill = Skill.FromGem(new Gem(skillVm.Definition.Id, skillVm.Level, skillVm.Quality, Slot,
+                        skillVm.SocketIndex, skillVm.GemGroup.Value - 1, skillVm.IsEnabled), true);
+                }
                 skills.Add(skill);
             }
 

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -116,8 +116,7 @@ namespace PoESkillTree.Views
 
         private ImportViewModels _importViewModels;
 
-        private readonly ObservableItemCollectionConverter
-            _equipmentConverter = new ObservableItemCollectionConverter();
+        private ObservableItemCollectionConverter? _equipmentConverter;
 
         private ComputationViewModel? _computationViewModel;
 
@@ -647,6 +646,8 @@ namespace PoESkillTree.Views
 
         private async Task InitializeComputationDependentAsync(ComputationInitializer computationInitializer)
         {
+            _equipmentConverter = new ObservableItemCollectionConverter(computationInitializer.CreateAdditionalSkillStatApplier());
+            _equipmentConverter.ConvertFrom(ItemAttributes);
             await computationInitializer.InitializeAfterBuildLoadAsync(
                 Tree.SkilledNodes,
                 _equipmentConverter.Equipment,
@@ -1635,7 +1636,7 @@ namespace PoESkillTree.Views
             }
 
             itemAttributes.ItemDataChanged += ItemAttributesOnItemDataChanged;
-            _equipmentConverter.ConvertFrom(itemAttributes);
+            _equipmentConverter?.ConvertFrom(itemAttributes);
             ItemAttributes = itemAttributes;
             InventoryViewModel =
                 new InventoryViewModel(_dialogCoordinator, itemAttributes, await GetJewelPassiveNodesAsync());

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -651,6 +651,7 @@ namespace PoESkillTree.Views
                 Tree.SkilledNodes,
                 _equipmentConverter.Equipment,
                 _equipmentConverter.Jewels,
+                _equipmentConverter.Gems,
                 _equipmentConverter.Skills);
             computationInitializer.SetupPeriodicActions();
             ComputationViewModel = await computationInitializer.CreateComputationViewModelAsync(PersistentData);

--- a/WPFSKillTree/Views/Skills/SkillsInSlotEditingView.xaml
+++ b/WPFSKillTree/Views/Skills/SkillsInSlotEditingView.xaml
@@ -33,8 +33,8 @@
         </Grid.ColumnDefinitions>
 
         <controls:SearchableComboBox Grid.Row="0" Grid.Column="0"
-                                     ItemsSource="{Binding AvailableSkills}"
-                                     SelectedItem="{Binding NewSkill.Definition}"
+                                     ItemsSource="{Binding AvailableGems}"
+                                     SelectedItem="{Binding NewGem.Definition}"
                                      SearchValuePath="Name"
                                      ToolTipService.InitialShowDelay="100"
                                      ToolTipService.ShowDuration="60000">
@@ -42,7 +42,7 @@
                 <ToolTip Padding="0"
                          BorderThickness="0">
                     <ToolTip.Content>
-                        <controls:ItemTooltip DataContext="{Binding NewSkill.ToolTip}" />
+                        <controls:ItemTooltip DataContext="{Binding NewGem.ToolTip}" />
                     </ToolTip.Content>
                 </ToolTip>
             </controls:SearchableComboBox.ToolTip>
@@ -57,24 +57,24 @@
             </controls:SearchableComboBox.ItemTemplate>
         </controls:SearchableComboBox>
         <mahapps:NumericUpDown Grid.Row="0" Grid.Column="1"
-                               Minimum="1" Maximum="{Binding NewSkill.Definition.MaxLevel}"
+                               Minimum="1" Maximum="{Binding NewGem.Definition.MaxLevel}"
                                NumericInputMode="Numbers"
-                               Value="{Binding NewSkill.Level}" />
+                               Value="{Binding NewGem.Level}" />
         <mahapps:NumericUpDown Grid.Row="0" Grid.Column="2"
                                Minimum="0" Maximum="30"
                                NumericInputMode="Numbers"
-                               Value="{Binding NewSkill.Quality}" />
+                               Value="{Binding NewGem.Quality}" />
         <mahapps:NumericUpDown Grid.Row="0" Grid.Column="3"
                                Minimum="1"
                                NumericInputMode="Numbers"
-                               Value="{Binding NewSkill.GemGroup}" />
+                               Value="{Binding NewGem.Group}" />
         <CheckBox Grid.Row="0" Grid.Column="4"
                   HorizontalAlignment="Left"
                   Margin="10 0 0 0"
-                  IsChecked="{Binding NewSkill.IsEnabled}" />
+                  IsChecked="{Binding NewGem.IsEnabled}" />
         <Button Grid.Row="0" Grid.Column="5"
                 HorizontalAlignment="Center"
-                Command="{Binding AddSkillCommand}">
+                Command="{Binding AddGemCommand}">
             <l:Catalog>Add</l:Catalog>
         </Button>
 
@@ -82,7 +82,7 @@
                   AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False"
                   CanUserResizeColumns="False"
                   VerticalScrollBarVisibility="Visible"
-                  ItemsSource="{Binding SkillsViewSource.View}">
+                  ItemsSource="{Binding GemsViewSource.View}">
             <DataGrid.Columns>
                 <DataGridTemplateColumn IsReadOnly="True"
                                         Width="4*">
@@ -90,7 +90,7 @@
                         <l:Catalog>Skill Name</l:Catalog>
                     </DataGridTemplateColumn.Header>
                     <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate DataType="viewModels:SkillViewModel">
+                        <DataTemplate DataType="viewModels:GemViewModel">
                             <DockPanel ToolTipService.InitialShowDelay="100"
                                        ToolTipService.ShowDuration="60000">
                                 <DockPanel.ToolTip>
@@ -169,7 +169,7 @@
                                         MaxWidth="60">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate DataType="viewModels:SkillViewModel">
-                            <Button Command="{Binding Data.RemoveSkillCommand, Source={StaticResource VmProxy}}"
+                            <Button Command="{Binding Data.RemoveGemCommand, Source={StaticResource VmProxy}}"
                                     CommandParameter="{Binding}"
                                     Width="20" Height="20"
                                     HorizontalAlignment="Center"

--- a/WPFSKillTree/Views/Skills/SkillsInSlotEditingView.xaml
+++ b/WPFSKillTree/Views/Skills/SkillsInSlotEditingView.xaml
@@ -114,7 +114,7 @@
                         <l:Catalog>Level</l:Catalog>
                     </DataGridTemplateColumn.Header>
                     <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate DataType="viewModels:SkillViewModel">
+                        <DataTemplate DataType="viewModels:GemViewModel">
                             <mahapps:NumericUpDown Style="{StaticResource UpDownInDataGridStyle}"
                                                    Minimum="1" Maximum="{Binding Definition.MaxLevel}"
                                                    NumericInputMode="Numbers"
@@ -128,7 +128,7 @@
                         <l:Catalog>Quality</l:Catalog>
                     </DataGridTemplateColumn.Header>
                     <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate DataType="viewModels:SkillViewModel">
+                        <DataTemplate DataType="viewModels:GemViewModel">
                             <mahapps:NumericUpDown Style="{StaticResource UpDownInDataGridStyle}"
                                                    Minimum="0" Maximum="30"
                                                    NumericInputMode="Numbers"
@@ -142,11 +142,11 @@
                         <l:Catalog>Group</l:Catalog>
                     </DataGridTemplateColumn.Header>
                     <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate DataType="viewModels:SkillViewModel">
+                        <DataTemplate DataType="viewModels:GemViewModel">
                             <mahapps:NumericUpDown Style="{StaticResource UpDownInDataGridStyle}"
                                                    Minimum="1"
                                                    NumericInputMode="Numbers"
-                                                   Value="{Binding GemGroup, UpdateSourceTrigger=PropertyChanged}" />
+                                                   Value="{Binding Group, UpdateSourceTrigger=PropertyChanged}" />
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
@@ -157,7 +157,7 @@
                         <l:Catalog>Enabled</l:Catalog>
                     </DataGridTemplateColumn.Header>
                     <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate DataType="viewModels:SkillViewModel">
+                        <DataTemplate DataType="viewModels:GemViewModel">
                             <CheckBox IsChecked="{Binding IsEnabled, UpdateSourceTrigger=PropertyChanged}"
                                       HorizontalAlignment="Left"
                                       Margin="10 0 0 0" />
@@ -168,7 +168,7 @@
                 <DataGridTemplateColumn Width="1*"
                                         MaxWidth="60">
                     <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate DataType="viewModels:SkillViewModel">
+                        <DataTemplate DataType="viewModels:GemViewModel">
                             <Button Command="{Binding Data.RemoveGemCommand, Source={StaticResource VmProxy}}"
                                     CommandParameter="{Binding}"
                                     Width="20" Height="20"

--- a/WPFSKillTree/Views/Skills/SkillsInSlotEditingView.xaml
+++ b/WPFSKillTree/Views/Skills/SkillsInSlotEditingView.xaml
@@ -91,20 +91,52 @@
                     </DataGridTemplateColumn.Header>
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate DataType="viewModels:GemViewModel">
-                            <DockPanel ToolTipService.InitialShowDelay="100"
-                                       ToolTipService.ShowDuration="60000">
-                                <DockPanel.ToolTip>
-                                    <ToolTip Padding="0"
-                                             BorderThickness="0">
-                                        <ToolTip.Content>
-                                            <controls:ItemTooltip DataContext="{Binding ToolTip}" />
-                                        </ToolTip.Content>
-                                    </ToolTip>
-                                </DockPanel.ToolTip>
-                                <Image Width="18" Margin="0 0 2 0"
-                                       Source="{Binding Definition.Icon.ImageSource.Result}" />
-                                <TextBlock Text="{Binding Definition.Name}" />
-                            </DockPanel>
+                            <StackPanel Orientation="Vertical">
+                                <DockPanel ToolTipService.InitialShowDelay="100"
+                                           ToolTipService.ShowDuration="60000">
+                                    <DockPanel.ToolTip>
+                                        <ToolTip Padding="0"
+                                                 BorderThickness="0">
+                                            <ToolTip.Content>
+                                                <controls:ItemTooltip DataContext="{Binding ToolTip}" />
+                                            </ToolTip.Content>
+                                        </ToolTip>
+                                    </DockPanel.ToolTip>
+                                    <Image Width="18" Margin="0 0 2 0"
+                                           Source="{Binding Definition.Icon.ImageSource.Result}" />
+                                    <TextBlock Text="{Binding Definition.Name}" />
+                                </DockPanel>
+                                <ItemsControl ItemsSource="{Binding Skills}"
+                                              Visibility="{Binding DisplaySkills, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                              Margin="10 2 0 2">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="viewModels:SkillViewModel">
+                                            <DockPanel Margin="0 2 0 0">
+                                                <CheckBox DockPanel.Dock="Left"
+                                                          
+                                                          IsChecked="{Binding IsEnabled}">
+                                                    <CheckBox.LayoutTransform>
+                                                        <ScaleTransform ScaleX="0.8" ScaleY="0.8" />
+                                                    </CheckBox.LayoutTransform>
+                                                </CheckBox>
+                                                <TextBlock Text="{Binding DisplayName}"
+                                                           VerticalAlignment="Center"
+                                                           ToolTipService.InitialShowDelay="100"
+                                                           ToolTipService.ShowDuration="60000">
+                                                    <TextBlock.ToolTip>
+                                                        <ToolTip Padding="0"
+                                                                 BorderThickness="0">
+                                                            <ToolTip.Content>
+                                                                <controls:ItemTooltip DataContext="{Binding ToolTip}" />
+                                                            </ToolTip.Content>
+                                                        </ToolTip>
+                                                    </TextBlock.ToolTip>
+                                                </TextBlock>
+                                            </DockPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/WPFSKillTree/WPFSKillTree.csproj
+++ b/WPFSKillTree/WPFSKillTree.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NLog" Version="4.6.8" />
-    <PackageReference Include="PoESkillTree.Engine" Version="0.2.0" />
+    <PackageReference Include="PoESkillTree.Engine" Version="0.2.1" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.0" />

--- a/WPFSKillTree/WPFSKillTree.csproj
+++ b/WPFSKillTree/WPFSKillTree.csproj
@@ -23,20 +23,20 @@
     <Exec Command="$(ProjectDir)build-locale.bat" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="ControlzEx" Version="4.2.0" />
+    <PackageReference Include="ControlzEx" Version="4.2.2" />
     <PackageReference Include="DynamicExpresso.Core" Version="2.3.1" />
-    <PackageReference Include="Enums.NET" Version="3.0.2" />
+    <PackageReference Include="Enums.NET" Version="3.0.3" />
     <PackageReference Include="Fluent.Ribbon" Version="7.0.1" />
     <PackageReference Include="gong-wpf-dragdrop" Version="2.2.0" />
     <PackageReference Include="MahApps.Metro" Version="2.0.0-alpha0660" />
-    <PackageReference Include="MahApps.Metro.IconPacks" Version="3.0.1" />
+    <PackageReference Include="MahApps.Metro.IconPacks" Version="3.3.0" />
     <PackageReference Include="MahApps.Metro.SimpleChildWindow" Version="2.0.0-alpha0032" />
-    <PackageReference Include="morelinq" Version="3.3.1" />
+    <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NLog" Version="4.6.8" />
-    <PackageReference Include="PoESkillTree.Engine" Version="0.1.10" />
+    <PackageReference Include="PoESkillTree.Engine" Version="0.2.0" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="System.Reactive" Version="4.3.1" />
+    <PackageReference Include="System.Reactive" Version="4.3.2" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
First part of #546.

Most of this happened in the Engine (see PoESkillTree/PoESkillTree.Engine#6 and PoESkillTree/PoESkillTree.Engine#7). This does mainly two things:

1. Split skill parsing into two steps: gem parsing and skill parsing.
2. Allow modifying the skills in between: additional level and quality (values come from the Engine) and enabling/disabling skills of gems that have secondary skills individually.

For active skills with secondary skills, enabling/disabling them can be done in the Skills UI:
![image](https://user-images.githubusercontent.com/7596346/76370566-91483100-6337-11ea-84cf-b82d5cbbcf8f.png)
